### PR TITLE
feat: prepare plugin for Codex and Claude marketplaces

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-marketplace.json",
+  "name": "exadel-agent-plugins",
+  "description": "AI agent development tools from Exadel.",
+  "owner": {
+    "name": "Exadel",
+    "url": "https://exadel.com"
+  },
+  "plugins": [
+    {
+      "name": "agentic-readiness-assessment",
+      "source": "./",
+      "description": "Evaluates a repository's readiness for AI coding agents and produces an evidence-based scorecard.",
+      "category": "development",
+      "tags": [
+        "agentic-readiness",
+        "codebase-analysis",
+        "assessment"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,12 +1,14 @@
 {
-  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "agentic-readiness-assessment",
+  "displayName": "Agentic Readiness Assessment",
   "version": "4.1.1",
   "description": "Evaluates a software repository for readiness to be developed and maintained by AI coding agents, and reports an evidence-based readiness scorecard.",
   "author": {
     "name": "Exadel",
     "url": "https://exadel.com"
   },
+  "homepage": "https://github.com/exadel-inc/agentic-readiness-assessment",
   "repository": "https://github.com/exadel-inc/agentic-readiness-assessment",
   "license": "Apache-2.0",
   "keywords": [

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,40 @@
+{
+  "name": "agentic-readiness-assessment",
+  "version": "4.1.1",
+  "description": "Evaluates a software repository for readiness to be developed and maintained by AI coding agents, and reports an evidence-based readiness scorecard.",
+  "author": {
+    "name": "Exadel",
+    "url": "https://exadel.com"
+  },
+  "homepage": "https://github.com/exadel-inc/agentic-readiness-assessment",
+  "repository": "https://github.com/exadel-inc/agentic-readiness-assessment",
+  "license": "Apache-2.0",
+  "keywords": [
+    "agentic-readiness",
+    "codebase-analysis",
+    "ai-agents",
+    "assessment"
+  ],
+  "skills": "./skills/",
+  "interface": {
+    "displayName": "Agentic Readiness Assessment",
+    "shortDescription": "Score a repository's readiness for AI coding agents.",
+    "longDescription": "Inspect a software repository in place, verify its agent development feedback loops, and produce an evidence-based readiness scorecard with prioritized recommendations.",
+    "developerName": "Exadel",
+    "category": "Developer Tools",
+    "capabilities": [
+      "Interactive",
+      "Write"
+    ],
+    "websiteURL": "https://github.com/exadel-inc/agentic-readiness-assessment",
+    "privacyPolicyURL": "https://exadel.com/privacy-policy",
+    "termsOfServiceURL": "https://exadel.com/terms-and-conditions",
+    "defaultPrompt": [
+      "Assess this repository's readiness for AI coding agents.",
+      "Generate an evidence-based agentic readiness scorecard.",
+      "Identify the highest-priority blockers to autonomous agent work."
+    ],
+    "brandColor": "#202020",
+    "logo": "./logo.png"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial plugin scaffold with the `agentic-readiness-assessment` skill.
 - Assessment prompt imported from its source repository.
 - Example report under `examples/`, from a run against a Next.js application, linked from the README.
+- Native Codex and Claude Code plugin manifests.
+- A self-hosted Claude Code marketplace catalog and publication guide.
 
 ### Removed
 
@@ -19,6 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The version in `plugin.json` is now the single source of truth for the skill, set to `4.1.0` so that `MAJOR.MINOR` continues the assessment prompt's prior revision history. The skill reads it and records it as `prompt_version` in generated reports. See [Versioning](README.md#versioning).
+- The version in `plugin.json` remains the canonical source of truth for the skill and is mirrored into platform manifests. It is now `4.1.1`; the skill reads the root manifest and records it as `prompt_version` in generated reports. See [Versioning](README.md#versioning).
 
 [Unreleased]: https://github.com/exadel-inc/agentic-readiness-assessment/commits/main

--- a/README.md
+++ b/README.md
@@ -45,15 +45,38 @@ The plugin ships a single Agent Skill, [`agentic-readiness-assessment`](skills/a
 
 ## Supported clients
 
-This is a skill written in the open [Agent Skills](https://agentskills.io/specification) format and ships with a portable [Agent Plugins](https://agent-plugins.org/specification) manifest, so any agent that reads those formats can pick it up.
+This is a skill written in the open [Agent Skills](https://agentskills.io/specification) format. It includes native manifests for Cursor-compatible Agent Plugins, Codex, and Claude Code:
 
-We are working towards listing it in every major marketplace, Cursor and Claude Code first, with the others and the community marketplaces to follow.
+- [`plugin.json`](plugin.json) for the portable [Agent Plugins](https://agent-plugins.org/specification) format used by Cursor;
+- [`.codex-plugin/plugin.json`](.codex-plugin/plugin.json) for ChatGPT and Codex;
+- [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json) for Claude Code.
+
+The three packages point to the same skill and require no backend or MCP server.
 
 ## Installation
 
-Once the plugin is published, install it from the [Cursor marketplace](https://cursor.com/marketplace).
+### Cursor
 
-To try it before publication, clone the repository and point Cursor at your local copy:
+Once published, install it from the [Cursor marketplace](https://cursor.com/marketplace).
+
+### Claude Code
+
+Add this repository as a marketplace and install the plugin:
+
+```sh
+claude plugin marketplace add exadel-inc/agentic-readiness-assessment
+claude plugin install agentic-readiness-assessment@exadel-agent-plugins
+```
+
+Until the marketplace file reaches the default branch, clone the repository and load it directly with `claude --plugin-dir .`.
+
+### ChatGPT and Codex
+
+Public installation will be available after OpenAI review and publication. The native Codex package is already present in the repository for submission and local packaging.
+
+### From source
+
+Clone the repository and point a compatible client at the repository root:
 
 ```sh
 git clone https://github.com/exadel-inc/agentic-readiness-assessment.git
@@ -122,17 +145,17 @@ More runs, and what was redacted before publishing, in [`examples/`](examples/RE
 
 ## Versioning
 
-The `version` field in [`plugin.json`](plugin.json) is the single source of truth. The skill does not carry its own version: it reads the manifest and records that value as `prompt_version` in the run block of every generated report, so any report can be traced back to the revision that produced it.
+The `version` field in [`plugin.json`](plugin.json) is the canonical source of truth. Platform marketplaces require self-contained manifests, so the same value is mirrored in [`.codex-plugin/plugin.json`](.codex-plugin/plugin.json) and [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json). The skill reads the portable root manifest and records that value as `prompt_version` in every generated report.
 
-The version is currently `4.1.0`. `MAJOR.MINOR` continues the assessment prompt's own revision history, which predates this repository, so reports produced here stay on one timeline with reports produced by earlier revisions of the prompt. `PATCH` covers packaging changes that leave the prompt untouched.
+The version is currently `4.1.1`. `MAJOR.MINOR` continues the assessment prompt's own revision history, which predates this repository, so reports produced here stay on one timeline with reports produced by earlier revisions of the prompt. `PATCH` covers packaging changes that leave the prompt untouched.
 
 Bump it as follows:
 
 | Change | Bump | Example |
 | --- | --- | --- |
-| The report contract breaks: scoring areas or weights, gates, readiness thresholds, or report sections change such that scores are no longer comparable | major | `4.1.0` → `5.0.0` |
-| The prompt changes while the report contract holds | minor | `4.1.0` → `4.2.0` |
-| Packaging, README, or manifest changes only, with no change to prompt semantics | patch | `4.1.0` → `4.1.1` |
+| The report contract breaks: scoring areas or weights, gates, readiness thresholds, or report sections change such that scores are no longer comparable | major | `4.1.1` → `5.0.0` |
+| The prompt changes while the report contract holds | minor | `4.1.1` → `4.2.0` |
+| Packaging, README, or manifest changes only, with no change to prompt semantics | patch | `4.1.1` → `4.1.2` |
 
 Scores are directly comparable across reports sharing the same `MAJOR.MINOR`. A minor bump may shift scores, so compare across one with care; a major bump breaks the contract, so do not compare across it at all.
 
@@ -146,6 +169,7 @@ git log --follow skills/agentic-readiness-assessment/SKILL.md
 
 - [Skill definition](skills/agentic-readiness-assessment/SKILL.md)
 - [Example reports](examples/README.md)
+- [Publishing guide](docs/PUBLISHING.md)
 - [Changelog](CHANGELOG.md)
 
 ## Contributing

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -1,0 +1,60 @@
+# Publishing
+
+This repository is one plugin root shared by Cursor, Codex, and Claude Code. The implementation stays in `skills/agentic-readiness-assessment/SKILL.md`; each platform-specific manifest only describes that shared skill.
+
+## Before a release
+
+1. Update the canonical version in `plugin.json` and mirror it in `.codex-plugin/plugin.json` and `.claude-plugin/plugin.json`.
+2. Record the change in `CHANGELOG.md`.
+3. Validate the JSON files:
+
+   ```sh
+   python3 -m json.tool plugin.json >/dev/null
+   python3 -m json.tool .codex-plugin/plugin.json >/dev/null
+   python3 -m json.tool .claude-plugin/plugin.json >/dev/null
+   python3 -m json.tool .claude-plugin/marketplace.json >/dev/null
+   ```
+
+4. Validate the Claude package with a current Claude Code release:
+
+   ```sh
+   claude plugin validate . --strict
+   ```
+
+5. Load the Claude plugin locally and verify that the skill is discoverable:
+
+   ```sh
+   claude --plugin-dir .
+   ```
+
+   In Claude Code, run `/agentic-readiness-assessment:agentic-readiness-assessment` from a disposable test repository.
+
+## Codex and ChatGPT
+
+Create a skills-only submission in the [OpenAI plugin submission portal](https://platform.openai.com/plugins). Upload an archive whose root contains `.codex-plugin/`, `skills/`, `logo.png`, `LICENSE`, and the other repository metadata required for review.
+
+The submission form also requires publisher verification, public support and legal URLs, listing assets, starter prompts, release notes, and positive and negative test cases. Automated safety and policy checks run before manual review. Approval does not publish the plugin automatically; publish the approved version from the portal.
+
+The assessment depends on local repository access and may run repository-provided validation commands. Call this out explicitly in the submission. OpenAI's [Claude plugin conversion guidance](https://developers.openai.com/plugins/guides/submit-claude-plugin) says plugins whose core value requires arbitrary local file or execution access may need product-specific review.
+
+For later versions, update all manifests, upload the new archive, submit that version for review, and publish it after approval.
+
+## Claude Code
+
+The repository is immediately usable as a self-hosted Claude marketplace after these files are present on the default branch:
+
+```sh
+claude plugin marketplace add exadel-inc/agentic-readiness-assessment
+claude plugin install agentic-readiness-assessment@exadel-agent-plugins
+```
+
+For public discovery, submit the plugin through the [Claude plugin submission form](https://platform.claude.com/plugins/submit). Third-party plugins that pass validation, automated safety screening, and review are published in the `claude-community` marketplace. The `claude-plugins-official` marketplace is curated separately by Anthropic and has no application process.
+
+After acceptance, verify the community catalog has synchronized, then test:
+
+```sh
+claude plugin marketplace add anthropics/claude-plugins-community
+claude plugin install agentic-readiness-assessment@claude-community
+```
+
+Anthropic pins an approved plugin to a repository commit and updates that pin as subsequent commits are reviewed by its pipeline. See the [Claude Code plugin documentation](https://code.claude.com/docs/en/plugins#submit-your-plugin-to-the-community-marketplace) for the current workflow.


### PR DESCRIPTION
# PR Details

## Description

This PR adds native packaging and marketplace metadata for Codex, ChatGPT, and Claude Code while keeping the existing Agent Skill as the shared implementation.

Changes include:

- Add the Codex plugin manifest under `.codex-plugin/`.
- Add the Claude Code plugin manifest and self-hosted marketplace catalog under `.claude-plugin/`.
- Document installation, validation, submission, and publication workflows.
- Update supported-client and versioning documentation.
- Bump the packaging version from `4.1.0` to `4.1.1` across all manifests.

## Motivation and Context

The repository previously only provided the portable Cursor-compatible manifest. Native manifests are required for platform-specific validation, installation, and marketplace submission.

These additions allow the same skill to be packaged for Codex, ChatGPT, and Claude Code without duplicating its implementation or changing assessment behavior.

## How Has This Been Tested

The following validation was performed on macOS:

- Parsed all plugin and marketplace manifests with `python3 -m json.tool`.
- Validated the Claude Code package in strict mode using Claude Code 2.1.258:

  ```sh
  claude plugin validate . --strict