### PR TITLE
feat: strengthen assessment skill assurance

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "agentic-readiness-assessment",
   "displayName": "Agentic Readiness Assessment",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "Evaluates a software repository for readiness to be developed and maintained by AI coding agents, and reports an evidence-based readiness scorecard.",
   "author": {
     "name": "Exadel",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "agentic-readiness-assessment",
   "displayName": "Agentic Readiness Assessment",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Evaluates a software repository for readiness to be developed and maintained by AI coding agents, and reports an evidence-based readiness scorecard.",
   "author": {
     "name": "Exadel",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "agentic-readiness-assessment",
   "displayName": "Agentic Readiness Assessment",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Evaluates a software repository for readiness to be developed and maintained by AI coding agents, and reports an evidence-based readiness scorecard.",
   "author": {
     "name": "Exadel",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "agentic-readiness-assessment",
   "displayName": "Agentic Readiness Assessment",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Evaluates a software repository for readiness to be developed and maintained by AI coding agents, and reports an evidence-based readiness scorecard.",
   "author": {
     "name": "Exadel",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-readiness-assessment",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "Evaluates a software repository for readiness to be developed and maintained by AI coding agents, and reports an evidence-based readiness scorecard.",
   "author": {
     "name": "Exadel",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-readiness-assessment",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Evaluates a software repository for readiness to be developed and maintained by AI coding agents, and reports an evidence-based readiness scorecard.",
   "author": {
     "name": "Exadel",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-readiness-assessment",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Evaluates a software repository for readiness to be developed and maintained by AI coding agents, and reports an evidence-based readiness scorecard.",
   "author": {
     "name": "Exadel",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-readiness-assessment",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Evaluates a software repository for readiness to be developed and maintained by AI coding agents, and reports an evidence-based readiness scorecard.",
   "author": {
     "name": "Exadel",

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 .idea/
 *.swp
 
+# Local git worktrees
+.worktrees/
+
 # Python (skill scripts)
 __pycache__/
 *.py[cod]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added dependency-free deterministic validation for the generated report contract.
 - Require host execution evidence for model identity, permissions, command boundaries, stop conditions, and context telemetry.
-- The version in `plugin.json` remains the canonical source of truth for the skill and is mirrored into platform manifests. It is now `4.3.0`; the skill reads the root manifest and records it as `prompt_version` in generated reports. See [Versioning](README.md#versioning).
+- Added the assessment delegation and decision record for deterministic calculations, report validation, and human approval boundaries.
+- The version in `plugin.json` remains the canonical source of truth for the skill and is mirrored into platform manifests. It is now `4.4.0`; the skill reads the root manifest and records it as `prompt_version` in generated reports. See [Versioning](README.md#versioning).
 
 [Unreleased]: https://github.com/exadel-inc/agentic-readiness-assessment/commits/main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added dependency-free deterministic validation for the generated report contract.
 - Require host execution evidence for model identity, permissions, command boundaries, stop conditions, and context telemetry.
 - Added the assessment delegation and decision record for deterministic calculations, report validation, and human approval boundaries.
-- The version in `plugin.json` remains the canonical source of truth for the skill and is mirrored into platform manifests. It is now `4.4.0`; the skill reads the root manifest and records it as `prompt_version` in generated reports. See [Versioning](README.md#versioning).
+- Made assessment instructions model-neutral, portable from an installed skill directory, and explicit about two-phase report finalization.
+- Strengthened report validation for status conditions, negative controls, Gate 3 anchor agreement, and escaped Markdown table pipes.
+- The version in `plugin.json` remains the canonical source of truth for the skill and is mirrored into platform manifests. It is now `4.5.0`; the skill reads the root manifest and records it as `prompt_version` in generated reports. See [Versioning](README.md#versioning).
 
 [Unreleased]: https://github.com/exadel-inc/agentic-readiness-assessment/commits/main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Added dependency-free deterministic validation for the generated report contract.
-- The version in `plugin.json` remains the canonical source of truth for the skill and is mirrored into platform manifests. It is now `4.2.0`; the skill reads the root manifest and records it as `prompt_version` in generated reports. See [Versioning](README.md#versioning).
+- Require host execution evidence for model identity, permissions, command boundaries, stop conditions, and context telemetry.
+- The version in `plugin.json` remains the canonical source of truth for the skill and is mirrored into platform manifests. It is now `4.3.0`; the skill reads the root manifest and records it as `prompt_version` in generated reports. See [Versioning](README.md#versioning).
 
 [Unreleased]: https://github.com/exadel-inc/agentic-readiness-assessment/commits/main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- The version in `plugin.json` remains the canonical source of truth for the skill and is mirrored into platform manifests. It is now `4.1.1`; the skill reads the root manifest and records it as `prompt_version` in generated reports. See [Versioning](README.md#versioning).
+- Added dependency-free deterministic validation for the generated report contract.
+- The version in `plugin.json` remains the canonical source of truth for the skill and is mirrored into platform manifests. It is now `4.2.0`; the skill reads the root manifest and records it as `prompt_version` in generated reports. See [Versioning](README.md#versioning).
 
 [Unreleased]: https://github.com/exadel-inc/agentic-readiness-assessment/commits/main

--- a/docs/superpowers/specs/2026-09-02-skill-assurance-design.md
+++ b/docs/superpowers/specs/2026-09-02-skill-assurance-design.md
@@ -1,0 +1,53 @@
+# Assessment Skill Assurance Design
+
+## Goal
+
+Make `agentic-readiness-assessment` a more reliable coding-agent skill by adding a deterministic report-contract check, an explicit host-runtime contract, and recorded architectural decisions without expanding its report beyond the existing thirteen sections.
+
+## Scope
+
+The solution addresses the solution-design audit gaps that the plugin can own. Host-enforced permission modes, model pinning, and token telemetry remain runtime responsibilities; the skill will require them to be recorded or explicitly marked unavailable rather than claiming to enforce them itself.
+
+## PR grouping
+
+### PR 1 — Deterministic report validation
+
+Add a dependency-free Python validator and unit tests. It will validate generated reports after the prompt's single write: thirteen ordered sections, one fixed glossary table, the required Run and Scope keys, score arithmetic, gate/anchor agreement, and Fix Record completeness. The prompt will require one corrective rewrite when validation fails and will record a validation result in the existing Confidence and Limits section.
+
+This makes report structure and arithmetic deterministic without attempting to parse repository-specific prose.
+
+### PR 2 — Agent execution contract
+
+Add a concise reference document that names the architecture as a coding-agent workflow: agentic repository investigation followed by deterministic assessment, validation, and report steps. It will define the required host-supplied evidence for model identity, permission profile, command boundary, run stop condition, and context telemetry. The prompt will use the contract before execution and report unavailable host evidence as an environment limitation.
+
+The reference is intentionally declarative. A portable skill cannot impose a host tool allowlist or pin a model; it can make those missing controls visible.
+
+### PR 3 — Assessment decision record
+
+Add a decision-record template and a delegation map for the assessment flow. They assign language interpretation to the model, command execution and arithmetic to deterministic tools, and scope/irreversible decisions to humans. Each decision records cost, complexity, risk, and a detection mechanism. The prompt will use this material to keep numeric scoring and report validation out of model judgement wherever a deterministic tool is available.
+
+## Data flow
+
+1. The agent reads the execution contract and records host evidence or an explicit limitation.
+2. It follows the delegated workflow: inspect, classify, execute safe repository commands, calculate through the deterministic helper, and write one report.
+3. It runs the validator against that report.
+4. A failed validator result permits one full corrective rewrite, followed by one recheck; an unresolved failure is reported as a repository-assessment limitation.
+
+## Compatibility
+
+The report retains its thirteen-section shape, scoring areas, weights, gates, statuses, and Fix Record fields. New validation and host-evidence details live in already-existing Run and Scope / Confidence and Limits prose, so this is a prompt-semantic minor release rather than a report-contract break.
+
+The release sequence is intentionally ordered: PR 1 supplies executable enforcement, PR 2 makes host limitations observable, and PR 3 documents the delegation and trade-offs used by both.
+
+## Testing
+
+PR 1 uses Python `unittest` and markdown fixtures. Tests first demonstrate rejection of a malformed report and acceptance of a valid minimal report. The JSON manifest validation in `docs/PUBLISHING.md` remains the packaging check for each PR.
+
+PRs 2 and 3 add documentation and prompt references; their regression checks run the validator tests and JSON validation, plus repository searches confirming the prompt references the new artifacts.
+
+## Non-goals
+
+- Do not add dependencies, remote services, or a custom agent runtime.
+- Do not claim that the skill can enforce host permission settings, model pinning, or context telemetry.
+- Do not add report sections or change scoring arithmetic.
+- Do not implement multi-agent fan-out for a linear assessment workflow.

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "agentic-readiness-assessment",
-  "version": "4.3.0",
+  "version": "4.4.0",
   "description": "Evaluates a software repository for readiness to be developed and maintained by AI coding agents, and reports an evidence-based readiness scorecard.",
   "author": {
     "name": "Exadel",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "agentic-readiness-assessment",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Evaluates a software repository for readiness to be developed and maintained by AI coding agents, and reports an evidence-based readiness scorecard.",
   "author": {
     "name": "Exadel",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "agentic-readiness-assessment",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "Evaluates a software repository for readiness to be developed and maintained by AI coding agents, and reports an evidence-based readiness scorecard.",
   "author": {
     "name": "Exadel",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "agentic-readiness-assessment",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Evaluates a software repository for readiness to be developed and maintained by AI coding agents, and reports an evidence-based readiness scorecard.",
   "author": {
     "name": "Exadel",

--- a/skills/agentic-readiness-assessment/SKILL.md
+++ b/skills/agentic-readiness-assessment/SKILL.md
@@ -305,7 +305,7 @@ Then list components, workspaces, and explicit constraints, including the five h
 
 ### 3. Glossary
 
-Reproduce the table below verbatim. It is fixed boilerplate: do not add terms, reword definitions, or expand it with repository-specific detail. Immediately below the table, add exactly one sentence in this format: `Gate 3 anchor: Area <4, 5, or 6> — <why this is the primary verification surface>.`
+Reproduce the table below verbatim. It is fixed boilerplate: do not add terms, reword definitions, or expand it with repository-specific detail. Immediately below the table, add exactly one sentence in this format: `Gate 3 anchor: Area <4, 5, or 6> — <why this is the primary verification surface>.` Add no other content to this section.
 
 | Term | Meaning |
 |---|---|
@@ -345,7 +345,12 @@ Open with a compact index table, repository-owned fixes first, then environment 
 
 `ID | Priority / Owner | Problem and blocked capability | Fix and target | Verify`
 
-Every cell must be actionable on its own. Each `F-nn` ID appears exactly once in the index and has exactly one matching record. Then give the authoritative full record for every `F-nn` ID, in ID order, with all nine fields. Start each record with `### F-nn`, then put each field on its own line as `**Problem:**`, `**Blocks:**`, `**Evidence:**`, `**Priority:**`, `**Owner:**`, `**Target:**`, `**Fix:**`, `**Verify:**`, and `**Level:**`. The index exists for triage and the records exist for execution; keep both, and keep their wording consistent.
+Every cell must be actionable on its own. The section begins with this exact compact-index header and separator, even when there are no Fix Records:
+
+`| ID | Priority / Owner | Problem and blocked capability | Fix and target | Verify |`
+`| --- | --- | --- | --- | --- |`
+
+Each `F-nn` ID appears exactly once in the index and has exactly one matching record. Then give the authoritative full record for every `F-nn` ID, in ID order, with all nine fields. Start each record with `### F-nn`, then put each field on its own line as `**Problem:**`, `**Blocks:**`, `**Evidence:**`, `**Priority:**`, `**Owner:**`, `**Target:**`, `**Fix:**`, `**Verify:**`, and `**Level:**`. The index exists for triage and the records exist for execution; keep both, and keep their wording consistent.
 
 ### 7. What Can Be Delegated Today
 

--- a/skills/agentic-readiness-assessment/SKILL.md
+++ b/skills/agentic-readiness-assessment/SKILL.md
@@ -299,13 +299,13 @@ One short paragraph: the score, overall status, confidence, a one-sentence readi
 
 ### 2. Run and Scope
 
-A single fenced yaml block with these keys in this order: `audited_by`, `prompt_version`, `started`, `completed`, `commit`, `branch`, `platform`, `archetype`, `scope`, `baseline_worktree`, `final_worktree`, `clean_state_setup` (verified, unfrozen fallback, warmed-workspace-only, or blocked with reason), `normalized_score`, `raw_total`, `applicable_maximum`, `status`, `confidence`, and a `gates` map. `raw_total` and `applicable_maximum` are integers; `normalized_score` is `round(raw_total / applicable_maximum * 100)`. Use this exact gate shape: `setup` has `anchor: 2` and its integer `score`; `deliverable` has `anchor: 3` and its integer `score`; `verification` has `anchor: 4`, `5`, or `6` and its integer `score`; `probe` has `result: pass`, `fail`, or `not attempted`. Each gate score equals its anchor area's earned score.
+A single fenced yaml block with exactly these top-level keys, in this order: `audited_by`, `prompt_version`, `started`, `completed`, `commit`, `branch`, `platform`, `archetype`, `scope`, `baseline_worktree`, `final_worktree`, `clean_state_setup` (verified, unfrozen fallback, warmed-workspace-only, or blocked with reason), `normalized_score`, `raw_total`, `applicable_maximum`, `status`, `confidence`, and a `gates` map. `raw_total` and `applicable_maximum` are integers; `normalized_score` is `round(raw_total / applicable_maximum * 100)`. Use this exact gate shape: `setup` has `anchor: 2` and its integer `score`; `deliverable` has `anchor: 3` and its integer `score`; `verification` has `anchor: 4`, `5`, or `6` and its integer `score`; `probe` has `result: pass`, `fail`, or `not attempted`. Each gate score equals its anchor area's earned score.
 
 Then list components, workspaces, and explicit constraints, including the five host-execution fields from `references/agent-execution-contract.md` or `unavailable` with their `agent-environment` limitation.
 
 ### 3. Glossary
 
-Reproduce the table below verbatim. It is fixed boilerplate: do not add terms, reword definitions, or expand it with repository-specific detail. Below the table, add one sentence naming which area anchors Gate 3 in this audit and why.
+Reproduce the table below verbatim. It is fixed boilerplate: do not add terms, reword definitions, or expand it with repository-specific detail. Immediately below the table, add exactly one sentence in this format: `Gate 3 anchor: Area <4, 5, or 6> — <why this is the primary verification surface>.`
 
 | Term | Meaning |
 |---|---|
@@ -345,7 +345,7 @@ Open with a compact index table, repository-owned fixes first, then environment 
 
 `ID | Priority / Owner | Problem and blocked capability | Fix and target | Verify`
 
-Every cell must be actionable on its own. Then give the authoritative full record for every `F-nn` ID, in ID order, with all nine fields. Start each record with `### F-nn`, then put each field on its own line as `**Problem:**`, `**Blocks:**`, `**Evidence:**`, `**Priority:**`, `**Owner:**`, `**Target:**`, `**Fix:**`, `**Verify:**`, and `**Level:**`. The index exists for triage and the records exist for execution; keep both, and keep their wording consistent.
+Every cell must be actionable on its own. Each `F-nn` ID appears exactly once in the index and has exactly one matching record. Then give the authoritative full record for every `F-nn` ID, in ID order, with all nine fields. Start each record with `### F-nn`, then put each field on its own line as `**Problem:**`, `**Blocks:**`, `**Evidence:**`, `**Priority:**`, `**Owner:**`, `**Target:**`, `**Fix:**`, `**Verify:**`, and `**Level:**`. The index exists for triage and the records exist for execution; keep both, and keep their wording consistent.
 
 ### 7. What Can Be Delegated Today
 

--- a/skills/agentic-readiness-assessment/SKILL.md
+++ b/skills/agentic-readiness-assessment/SKILL.md
@@ -299,7 +299,7 @@ One short paragraph: the score, overall status, confidence, a one-sentence readi
 
 ### 2. Run and Scope
 
-A single fenced yaml block with these keys in this order: `audited_by`, `prompt_version`, `started`, `completed`, `commit`, `branch`, `platform`, `archetype`, `scope`, `baseline_worktree`, `final_worktree`, `clean_state_setup` (verified, unfrozen fallback, warmed-workspace-only, or blocked with reason), `normalized_score`, `raw_total`, `applicable_maximum`, `status`, `confidence`, and a `gates` map with `setup`, `deliverable`, `verification`, and `probe`.
+A single fenced yaml block with these keys in this order: `audited_by`, `prompt_version`, `started`, `completed`, `commit`, `branch`, `platform`, `archetype`, `scope`, `baseline_worktree`, `final_worktree`, `clean_state_setup` (verified, unfrozen fallback, warmed-workspace-only, or blocked with reason), `normalized_score`, `raw_total`, `applicable_maximum`, `status`, `confidence`, and a `gates` map. `raw_total` and `applicable_maximum` are integers; `normalized_score` is `round(raw_total / applicable_maximum * 100)`. Use this exact gate shape: `setup` has `anchor: 2` and its integer `score`; `deliverable` has `anchor: 3` and its integer `score`; `verification` has `anchor: 4`, `5`, or `6` and its integer `score`; `probe` has `result: pass`, `fail`, or `not attempted`. Each gate score equals its anchor area's earned score.
 
 Then list components, workspaces, and explicit constraints, including the five host-execution fields from `references/agent-execution-contract.md` or `unavailable` with their `agent-environment` limitation.
 
@@ -331,7 +331,7 @@ Use:
 
 `Area | Applicability | Status | Score | Verification | Evidence / Result | Fix IDs`
 
-Include all fourteen areas, then the area 13 capability breakdown and any negative controls found. Close with the raw total, applicable maximum, every N/A subtraction, the addends on one line, and the normalized score. Gate results belong in the next section; confidence belongs in sections 1 and 13.
+Include all fourteen areas, then the area 13 capability breakdown and any negative controls found. Every area row uses exactly one allowed status — `Verified`, `Partial`, `Repository-blocked`, or `N/A` — and a Score of `earned/max`; `N/A` uses `N/A`. The earned score is the area's maximum for `Verified`, half rounded down for `Partial`, and zero for `Repository-blocked`. Close with the raw total, applicable maximum, every N/A subtraction, the addends on one line, and the normalized score. Gate results belong in the next section; confidence belongs in sections 1 and 13.
 
 The `Fix IDs` column lists IDs only. Do not restate problems here.
 
@@ -345,7 +345,7 @@ Open with a compact index table, repository-owned fixes first, then environment 
 
 `ID | Priority / Owner | Problem and blocked capability | Fix and target | Verify`
 
-Every cell must be actionable on its own. Then give the authoritative full record for every `F-nn` ID, in ID order, with all nine fields. The index exists for triage and the records exist for execution; keep both, and keep their wording consistent.
+Every cell must be actionable on its own. Then give the authoritative full record for every `F-nn` ID, in ID order, with all nine fields. Start each record with `### F-nn`, then put each field on its own line as `**Problem:**`, `**Blocks:**`, `**Evidence:**`, `**Priority:**`, `**Owner:**`, `**Target:**`, `**Fix:**`, `**Verify:**`, and `**Level:**`. The index exists for triage and the records exist for execution; keep both, and keep their wording consistent.
 
 ### 7. What Can Be Delegated Today
 

--- a/skills/agentic-readiness-assessment/SKILL.md
+++ b/skills/agentic-readiness-assessment/SKILL.md
@@ -84,6 +84,10 @@ Do not invent an external file path or configuration key. If the exact target ca
 
 ## Audit Method
 
+### Delegation
+
+Read `references/assessment-decision-record.md` before baseline collection. Use Claude only to interpret repository evidence; use deterministic commands for score arithmetic and `scripts/validate_report.py` for report validation. The requesting human owns scope constraints and must approve an irreversible operation before it runs; otherwise stop and record the command as refused. Keep the delegation map's Cost / Complexity / Risk discipline in the evidence and report the named detection mechanism for any limitation.
+
 ### 1. Baseline and Scope
 
 Capture the baseline before anything else: tracked and untracked worktree state, stash list, commit, and branch. A dirty tree or pre-existing untracked directory is the baseline, not an error. Record the platform, explicit constraints, and relevant installed tools.
@@ -389,7 +393,8 @@ Re-read the report and verify:
 - the probe section reports either a completed probe or an explicit reason it was not attempted;
 - the report contains only commands actually executed or explicitly refused as unsafe;
 - the final worktree differs from the baseline only by the report and known audit-created ignored artifacts, with the probe edit reverted.
-- `python3 skills/agentic-readiness-assessment/scripts/validate_report.py reports/agentic-readiness.md` exits 0.
+- `python3 skills/agentic-readiness-assessment/scripts/validate_report.py reports/agentic-readiness.md` exits 0, with its command and result recorded in Commands Executed;
+- any unavailable host-execution control is recorded in Run and Scope constraints and Confidence and Limits as an `agent-environment` limitation.
 
 If the validator fails, make one corrective rewrite of the report and run it once more. Record any unresolved validator errors in Confidence and Limits; say that you rewrote it, then stop.
 

--- a/skills/agentic-readiness-assessment/SKILL.md
+++ b/skills/agentic-readiness-assessment/SKILL.md
@@ -48,6 +48,8 @@ Classify commands before execution:
 - **privileged:** Requires root, `sudo`, or machine-wide changes. Do not run.
 - **paid:** Calls a billed external service. Do not run.
 
+After the report's single write, run `python3 skills/agentic-readiness-assessment/scripts/validate_report.py reports/agentic-readiness.md`. This is a `local-read` command: it validates the report contract without changing the repository. Record it in Commands Executed.
+
 Being documented does not make a command safe. A refused command is not a skipped category: record it, name its class, and score on the safe evidence that remains.
 
 ### Dependency Installation
@@ -383,7 +385,8 @@ Re-read the report and verify:
 - the probe section reports either a completed probe or an explicit reason it was not attempted;
 - the report contains only commands actually executed or explicitly refused as unsafe;
 - the final worktree differs from the baseline only by the report and known audit-created ignored artifacts, with the probe edit reverted.
+- `python3 skills/agentic-readiness-assessment/scripts/validate_report.py reports/agentic-readiness.md` exits 0.
 
-You may make one corrective rewrite if a check failed; say that you rewrote it, then stop.
+If the validator fails, make one corrective rewrite of the report and run it once more. Record any unresolved validator errors in Confidence and Limits; say that you rewrote it, then stop.
 
 Then respond with the report path, score, overall status, confidence, failed gates, the probe result, and the first repository-owned fix.

--- a/skills/agentic-readiness-assessment/SKILL.md
+++ b/skills/agentic-readiness-assessment/SKILL.md
@@ -15,11 +15,11 @@ Read the `version` field of the plugin's `plugin.json` and record it as `prompt_
 
 ## Objective
 
-Assess whether an AI coding agent can independently understand this repository, find the correct change points, establish a reproducible environment, validate work, and prepare a change for delivery. Produce an evidence-backed improvement backlog for the FDE team.
+Assess whether an AI coding agent can independently understand this repository, find the correct change points, establish a reproducible environment, validate work, and prepare a change for delivery. Produce an evidence-backed improvement backlog for maintainers.
 
-This is an audit. Do not implement features or refactor production code. Create only one file: `reports/agentic-readiness.md`, a single document holding both the FDE decision content and the supporting evidence.
+This is an audit. Do not implement features or refactor production code. Create only one file: `reports/agentic-readiness.md`, a single document holding both the decision content and the supporting evidence.
 
-Create `reports/` if needed. The only permitted change to any other tracked file is the single reversible probe edit described in *Probe*, which you revert before writing the report. Preserve all pre-existing user changes.
+The only permitted change to any other tracked file is the single reversible probe edit described in *Probe*, which you revert before writing the report. Preserve all pre-existing user changes.
 
 The deliverable of this task is that report. Any standing instruction to output only code, or to treat an analysis document as a failed task, applies to feature work and not to this audit.
 
@@ -52,7 +52,7 @@ Classify commands before execution:
 - **privileged:** Requires root, `sudo`, or machine-wide changes. Do not run.
 - **paid:** Calls a billed external service. Do not run.
 
-After the report's single write, run `python3 skills/agentic-readiness-assessment/scripts/validate_report.py reports/agentic-readiness.md`. This is a `local-read` command: it validates the report contract without changing the repository. Record it in Commands Executed.
+Run `python3 <skill-directory>/scripts/validate_report.py reports/agentic-readiness.md` from the audited repository after the provisional report write; `<skill-directory>` is the directory containing this `SKILL.md`, not a path inside the audited repository. This is a `local-read` command that validates the report contract without changing the repository.
 
 Being documented does not make a command safe. A refused command is not a skipped category: record it, name its class, and score on the safe evidence that remains.
 
@@ -86,7 +86,7 @@ Do not invent an external file path or configuration key. If the exact target ca
 
 ### Delegation
 
-Read `references/assessment-decision-record.md` before baseline collection. Use Claude only to interpret repository evidence; use deterministic commands for score arithmetic and `scripts/validate_report.py` for report validation. The requesting human owns scope constraints and must approve an irreversible operation before it runs; otherwise stop and record the command as refused. Keep the delegation map's Cost / Complexity / Risk discipline in the evidence and report the named detection mechanism for any limitation.
+Read `references/assessment-decision-record.md` before baseline collection. Use the audit agent only to interpret repository evidence; use deterministic commands for score arithmetic and `scripts/validate_report.py` for report validation. The requesting human owns scope constraints and must approve an irreversible operation before it runs; otherwise stop and record the command as refused. Keep the delegation map's Cost / Complexity / Risk discipline in the evidence and report the named detection mechanism for any limitation.
 
 ### 1. Baseline and Scope
 
@@ -279,7 +279,7 @@ Order records by priority, then by expected effort when reasonably known, so the
 
 ## Output Quality Rules
 
-- Give every line a consumer and a decision or action it enables. There are two consumers: the FDE deciding what to repair and delegate, and the agent consuming structured state to plan or re-run.
+- Give every line a consumer and a decision or action it enables. There are two consumers: the maintainer deciding what to repair and delegate, and the agent consuming structured state to plan or re-run.
 - State each problem authoritatively in its Fix Record. Elsewhere cite its ID — but a table an FDE acts on must still carry complete wording. **Never write a bare `See F-01` in a cell whose purpose is to tell someone what to do.**
 - Every scorecard cell cites a command row or a `path:line`.
 - Do not add consistently empty columns or write `not measured` repeatedly. Include duration only when measured.
@@ -287,7 +287,7 @@ Order records by priority, then by expected effort when reasonably known, so the
 - Do not create a finding without a fix, or a fix without a finding.
 - State each fact where the report assigns it and do not restate it elsewhere. The score, status, and confidence belong in the run block; the verdict paragraph interprets them in prose without repeating the commit or prompt version.
 - No table exceeds seven columns; one line per cell; escape literal pipes as `\|`.
-- Write the report in a single write operation using the file-editing tool. Never assemble it with shell heredocs.
+- Write the provisional report in one file-editing operation. Never assemble it with shell heredocs. The finalization exception in Final Validation permits the bounded rewrites needed to validate and truthfully record that command.
 
 ## Report
 
@@ -299,7 +299,7 @@ One short paragraph: the score, overall status, confidence, a one-sentence readi
 
 ### 2. Run and Scope
 
-A single fenced yaml block with exactly these top-level keys, in this order: `audited_by`, `prompt_version`, `started`, `completed`, `commit`, `branch`, `platform`, `archetype`, `scope`, `baseline_worktree`, `final_worktree`, `clean_state_setup` (verified, unfrozen fallback, warmed-workspace-only, or blocked with reason), `normalized_score`, `raw_total`, `applicable_maximum`, `status`, `confidence`, and a `gates` map. `raw_total` and `applicable_maximum` are integers; `normalized_score` is `round(raw_total / applicable_maximum * 100)`. Use this exact gate shape: `setup` has `anchor: 2` and its integer `score`; `deliverable` has `anchor: 3` and its integer `score`; `verification` has `anchor: 4`, `5`, or `6` and its integer `score`; `probe` has `result: pass`, `fail`, or `not attempted`. Each gate score equals its anchor area's earned score.
+A single fenced yaml block with exactly these top-level keys, in this order: `audited_by`, `prompt_version`, `started`, `completed`, `commit`, `branch`, `platform`, `archetype`, `scope`, `baseline_worktree`, `final_worktree`, `clean_state_setup` (verified, unfrozen fallback, warmed-workspace-only, or blocked with reason), `normalized_score`, `raw_total`, `applicable_maximum`, `status`, `confidence`, and a `gates` map. Follow `references/report-contract.md` for the machine-checked values and gate shape.
 
 Then list components, workspaces, and explicit constraints, including the five host-execution fields from `references/agent-execution-contract.md` or `unavailable` with their `agent-environment` limitation.
 
@@ -331,7 +331,7 @@ Use:
 
 `Area | Applicability | Status | Score | Verification | Evidence / Result | Fix IDs`
 
-Include all fourteen areas, then the area 13 capability breakdown and any negative controls found. Every area row uses exactly one allowed status — `Verified`, `Partial`, `Repository-blocked`, or `N/A` — and a Score of `earned/max`; `N/A` uses `N/A`. The earned score is the area's maximum for `Verified`, half rounded down for `Partial`, and zero for `Repository-blocked`. Close with the raw total, applicable maximum, every N/A subtraction, the addends on one line, and the normalized score. Gate results belong in the next section; confidence belongs in sections 1 and 13.
+Include all fourteen areas, then the area 13 capability breakdown and any negative controls found. Follow `references/report-contract.md` for the machine-checked score and negative-control notation. Close with the raw total, applicable maximum, every N/A subtraction, the addends on one line, and the normalized score. Gate results belong in the next section; confidence belongs in sections 1 and 13.
 
 The `Fix IDs` column lists IDs only. Do not restate problems here.
 
@@ -345,16 +345,11 @@ Open with a compact index table, repository-owned fixes first, then environment 
 
 `ID | Priority / Owner | Problem and blocked capability | Fix and target | Verify`
 
-Every cell must be actionable on its own. The section begins with this exact compact-index header and separator, even when there are no Fix Records:
-
-`| ID | Priority / Owner | Problem and blocked capability | Fix and target | Verify |`
-`| --- | --- | --- | --- | --- |`
-
-Each `F-nn` ID appears exactly once in the index and has exactly one matching record. Then give the authoritative full record for every `F-nn` ID, in ID order, with all nine fields. Start each record with `### F-nn`, then put each field on its own line as `**Problem:**`, `**Blocks:**`, `**Evidence:**`, `**Priority:**`, `**Owner:**`, `**Target:**`, `**Fix:**`, `**Verify:**`, and `**Level:**`. The index exists for triage and the records exist for execution; keep both, and keep their wording consistent.
+Every cell must be actionable on its own. Follow `references/report-contract.md` for the compact index. Each `F-nn` ID appears exactly once in the index and has exactly one matching record. Then give the authoritative full record for every `F-nn` ID, in ID order, with all nine fields. Start each record with `### F-nn`, then put each field on its own line as `**Problem:**`, `**Blocks:**`, `**Evidence:**`, `**Priority:**`, `**Owner:**`, `**Target:**`, `**Fix:**`, `**Verify:**`, and `**Level:**`. The index exists for triage and the records exist for execution; keep both, and keep their wording consistent.
 
 ### 7. What Can Be Delegated Today
 
-Rate research, implementation, testing, deliverable validation, runtime or API validation, browser validation, and autonomous task-to-PR delivery as Yes, Partially, No, or N/A, each with the gate or Fix Record IDs behind it. Rate autonomous delivery **Yes** only when every gate passes, the probe succeeded, and area 13 scored prevention points above zero.
+Rate the work an AI coding agent can independently undertake today — research, implementation, testing, deliverable validation, runtime or API validation, browser validation, and autonomous task-to-PR delivery — as Yes, Partially, No, or N/A, each with the gate or Fix Record IDs behind it. Rate autonomous delivery **Yes** only when every gate passes, the probe succeeded, and area 13 scored prevention points above zero.
 
 ### 8. What Is Already Good
 
@@ -398,9 +393,9 @@ Re-read the report and verify:
 - the probe section reports either a completed probe or an explicit reason it was not attempted;
 - the report contains only commands actually executed or explicitly refused as unsafe;
 - the final worktree differs from the baseline only by the report and known audit-created ignored artifacts, with the probe edit reverted.
-- `python3 skills/agentic-readiness-assessment/scripts/validate_report.py reports/agentic-readiness.md` exits 0, with its command and result recorded in Commands Executed;
+- `python3 <skill-directory>/scripts/validate_report.py reports/agentic-readiness.md` exits 0;
 - any unavailable host-execution control is recorded in Run and Scope constraints and Confidence and Limits as an `agent-environment` limitation.
 
-If the validator fails, make one corrective rewrite of the report and run it once more. Record any unresolved validator errors in Confidence and Limits; say that you rewrote it, then stop.
+Finalization exception: write the provisional report, run the validator, and make one corrective rewrite only if it fails. Run the validator once more after that correction. Then make one finalization rewrite that changes only Commands Executed and Confidence and Limits to record the last validator command and result. The finalization rewrite is permitted even when the provisional report passed; no other rewrite is allowed. Record unresolved validator errors in Confidence and Limits; say that you rewrote it, then stop.
 
 Then respond with the report path, score, overall status, confidence, failed gates, the probe result, and the first repository-owned fix.

--- a/skills/agentic-readiness-assessment/SKILL.md
+++ b/skills/agentic-readiness-assessment/SKILL.md
@@ -23,6 +23,10 @@ Create `reports/` if needed. The only permitted change to any other tracked file
 
 The deliverable of this task is that report. Any standing instruction to output only code, or to treat an analysis document as a failed task, applies to feature work and not to this audit.
 
+## Host Execution Contract
+
+Read `references/agent-execution-contract.md` before collecting the baseline. Under the explicit constraints in Run and Scope, record the host's model identity, effective permission profile, command boundary, run stop condition, and context telemetry availability. Write `unavailable` for any field the host cannot evidence, classify it as an `agent-environment` limitation, and never invent a tool restriction, model pin, or telemetry control. After roughly five attempts to obtain unavailable evidence, stop and record the limitation.
+
 ## Evidence and Safety Rules
 
 1. Cite repository-relative paths and line numbers for repository claims.
@@ -293,7 +297,7 @@ One short paragraph: the score, overall status, confidence, a one-sentence readi
 
 A single fenced yaml block with these keys in this order: `audited_by`, `prompt_version`, `started`, `completed`, `commit`, `branch`, `platform`, `archetype`, `scope`, `baseline_worktree`, `final_worktree`, `clean_state_setup` (verified, unfrozen fallback, warmed-workspace-only, or blocked with reason), `normalized_score`, `raw_total`, `applicable_maximum`, `status`, `confidence`, and a `gates` map with `setup`, `deliverable`, `verification`, and `probe`.
 
-Then list components, workspaces, and explicit constraints.
+Then list components, workspaces, and explicit constraints, including the five host-execution fields from `references/agent-execution-contract.md` or `unavailable` with their `agent-environment` limitation.
 
 ### 3. Glossary
 

--- a/skills/agentic-readiness-assessment/references/agent-execution-contract.md
+++ b/skills/agentic-readiness-assessment/references/agent-execution-contract.md
@@ -1,0 +1,15 @@
+# Agent execution contract
+
+`agentic-readiness-assessment` is a **coding-agent workflow**: agentic repository investigation determines the relevant change and validation surfaces; deterministic tooling classifies commands, executes safe checks, and validates the finished report; a human controls scope and any irreversible action.
+
+Before an assessment starts, the host runtime must provide or explicitly withhold the following evidence:
+
+| Evidence | Record | If unavailable |
+|---|---|---|
+| Model identity | Provider, model identifier, and version or alias | `unavailable`; do not claim a pinned model. |
+| Effective permission profile | The host's tool and path restrictions | `unavailable`; do not claim a tool allowlist. |
+| Command boundary | Which command classes the host can run or refuse | `unavailable`; classify the resulting limitation. |
+| Run stop condition | The host's turn, time, or cancellation limit | `unavailable`; retain the assessment's five-attempt discipline. |
+| Context telemetry | Whether token usage, truncation, or context-limit signals are exposed | `unavailable`; do not infer context safety. |
+
+Record the five fields or `unavailable` under the explicit constraints in **Run and Scope**. Missing host evidence is an `agent-environment` limitation on the assessment's confidence, not a repository finding. A portable prompt can request and record this evidence; it cannot enforce host permissions, pin a model, or add context telemetry.

--- a/skills/agentic-readiness-assessment/references/assessment-decision-record.md
+++ b/skills/agentic-readiness-assessment/references/assessment-decision-record.md
@@ -1,12 +1,12 @@
 # Assessment Delegation and Decision Record
 
-Use this record before running an assessment. It names who owns each step so a language model does not silently become the owner of arithmetic, command safety, or an irreversible decision.
+Use this record before running an assessment. It names who owns each step so the audit agent does not silently become the owner of arithmetic, command safety, or an irreversible decision.
 
 ## Delegation map
 
 | Step | Owner | Reversibility / stakes | Accountability | Detection mechanism |
 |---|---|---|---|---|
-| Interpret repository structure and evidence | Claude | Reversible analysis; an unsupported conclusion can misdirect a repair backlog. | The audit agent must cite evidence and label uncertainty. | Every repository claim carries a path and line or command result; any uncited claim is rejected in report review. Owner: FDE reviewer. |
+| Interpret repository structure and evidence | Audit agent | Reversible analysis; an unsupported conclusion can misdirect a repair backlog. | The audit agent must cite evidence and label uncertainty. | Every repository claim carries a path and line or command result; any uncited claim is rejected in report review. Owner: report reviewer. |
 | Execute approved commands, calculate totals, and validate report shape | Deterministic tooling | Commands may create local artifacts; a wrong score or malformed report makes a decision unreliable. | The audit agent selects only safe commands and records their result. | The command inventory contains every executed command; the validator must exit `0`; score addends must differ from the stated raw total by `0`. Owner: audit agent. |
 | Set scope constraints and approve irreversible actions | Human | Irreversible or external actions can change customer, production, or shared state. | The requesting human owns scope and authorization. | Stop before any irreversible, external-write, privileged, paid, or otherwise unclassified action; no such command may appear as executed without approval. Owner: requesting human. |
 
@@ -22,7 +22,7 @@ Use this record before running an assessment. It names who owns each step so a l
 
 **Risk:** A command can mutate state or contact an external system despite looking routine.
 
-**Detection mechanism:** The Commands Executed inventory is reviewed for every command with a non-local safety class; threshold: `0` unapproved external-write, privileged, paid, or unclassified commands. Owner: FDE reviewer.
+**Detection mechanism:** The Commands Executed inventory is reviewed for every command with a non-local safety class; threshold: `0` unapproved external-write, privileged, paid, or unclassified commands. Owner: report reviewer.
 
 ### Score calculation
 
@@ -38,11 +38,11 @@ Use this record before running an assessment. It names who owns each step so a l
 
 ### Report validation
 
-**Decision:** Run `python3 skills/agentic-readiness-assessment/scripts/validate_report.py reports/agentic-readiness.md` after the report's single write.
+**Decision:** Run `python3 <skill-directory>/scripts/validate_report.py reports/agentic-readiness.md` after the provisional report write, where `<skill-directory>` contains this skill's `SKILL.md`.
 
 **Cost:** A local Python process and, at most, one corrective rewrite.
 
-**Complexity:** The report must retain the fixed headings, Run and Scope keys, and glossary shape the validator checks.
+**Complexity:** The report must retain the fixed headings, Run and Scope keys, and glossary shape the validator checks, then use the bounded finalization rewrite to record the validator result.
 
 **Risk:** A malformed report can look complete while breaking automated consumption or audit comparison.
 

--- a/skills/agentic-readiness-assessment/references/assessment-decision-record.md
+++ b/skills/agentic-readiness-assessment/references/assessment-decision-record.md
@@ -1,0 +1,49 @@
+# Assessment Delegation and Decision Record
+
+Use this record before running an assessment. It names who owns each step so a language model does not silently become the owner of arithmetic, command safety, or an irreversible decision.
+
+## Delegation map
+
+| Step | Owner | Reversibility / stakes | Accountability | Detection mechanism |
+|---|---|---|---|---|
+| Interpret repository structure and evidence | Claude | Reversible analysis; an unsupported conclusion can misdirect a repair backlog. | The audit agent must cite evidence and label uncertainty. | Every repository claim carries a path and line or command result; any uncited claim is rejected in report review. Owner: FDE reviewer. |
+| Execute approved commands, calculate totals, and validate report shape | Deterministic tooling | Commands may create local artifacts; a wrong score or malformed report makes a decision unreliable. | The audit agent selects only safe commands and records their result. | The command inventory contains every executed command; the validator must exit `0`; score addends must differ from the stated raw total by `0`. Owner: audit agent. |
+| Set scope constraints and approve irreversible actions | Human | Irreversible or external actions can change customer, production, or shared state. | The requesting human owns scope and authorization. | Stop before any irreversible, external-write, privileged, paid, or otherwise unclassified action; no such command may appear as executed without approval. Owner: requesting human. |
+
+## Decision records
+
+### Command execution
+
+**Decision:** Classify each command and execute only `local-read` or safe `local-build` work without additional approval.
+
+**Cost:** Command classification and recording add a small amount of audit time.
+
+**Complexity:** The agent must keep a command inventory and clean up only artifacts it created.
+
+**Risk:** A command can mutate state or contact an external system despite looking routine.
+
+**Detection mechanism:** The Commands Executed inventory is reviewed for every command with a non-local safety class; threshold: `0` unapproved external-write, privileged, paid, or unclassified commands. Owner: FDE reviewer.
+
+### Score calculation
+
+**Decision:** Calculate raw totals, applicable maximum, and normalized score with deterministic tooling, not model arithmetic.
+
+**Cost:** One local calculation command per report.
+
+**Complexity:** The agent must preserve the scorecard addends and record the calculation inputs.
+
+**Risk:** A transcription or arithmetic error can produce a plausible but incorrect readiness status.
+
+**Detection mechanism:** Re-add the scorecard values with a local calculation; threshold: stated raw total and normalized score differ by `0` from the calculated values. Owner: audit agent.
+
+### Report validation
+
+**Decision:** Run `python3 skills/agentic-readiness-assessment/scripts/validate_report.py reports/agentic-readiness.md` after the report's single write.
+
+**Cost:** A local Python process and, at most, one corrective rewrite.
+
+**Complexity:** The report must retain the fixed headings, Run and Scope keys, and glossary shape the validator checks.
+
+**Risk:** A malformed report can look complete while breaking automated consumption or audit comparison.
+
+**Detection mechanism:** Validator process exit status; threshold: exit code must be `0` after at most one corrective rewrite. Owner: audit agent.

--- a/skills/agentic-readiness-assessment/references/report-contract.md
+++ b/skills/agentic-readiness-assessment/references/report-contract.md
@@ -1,0 +1,37 @@
+# Report Contract
+
+Use this reference only while assembling the report.
+
+## Run and Scope
+
+The YAML block has the top-level keys listed in `SKILL.md`, in that order. `raw_total` and `applicable_maximum` are integers; `normalized_score` is `round(raw_total / applicable_maximum * 100)`.
+
+```yaml
+gates:
+  setup:
+    anchor: 2
+    score: <earned area score>
+  deliverable:
+    anchor: 3
+    score: <earned area score>
+  verification:
+    anchor: <4, 5, or 6>
+    score: <earned area score>
+  probe:
+    result: <pass|fail|not attempted>
+```
+
+Each gate score equals its anchor area’s earned score.
+
+## Scorecard and findings
+
+Each area score is `earned/max`; `N/A` uses `N/A`. Add exactly one line after the scorecard: `Negative controls: none` or `Negative controls: F-nn, F-nn`.
+
+Start What to Fix with:
+
+```markdown
+| ID | Priority / Owner | Problem and blocked capability | Fix and target | Verify |
+| --- | --- | --- | --- | --- |
+```
+
+Each indexed `F-nn` has one matching `### F-nn` record with the nine fields specified in `SKILL.md`.

--- a/skills/agentic-readiness-assessment/scripts/validate_report.py
+++ b/skills/agentic-readiness-assessment/scripts/validate_report.py
@@ -40,38 +40,171 @@ RUN_KEYS = (
     "confidence",
     "gates",
 )
+AREAS = (
+    ("Agent guidance and navigation", 10),
+    ("Reproducible environment and dependency setup", 10),
+    ("Build, package, render, or deliverable validation", 10),
+    ("Lint, format check, typecheck, static analysis, or policy validation", 10),
+    ("Unit or component tests", 10),
+    ("Integration, contract, or functional tests", 5),
+    ("Runtime, API, CLI, or local-preview validation", 5),
+    ("Browser or UI validation", 5),
+    ("Coverage and feedback-loop quality", 5),
+    ("CI enforcement and parity with local validation", 10),
+    ("Safety, test isolation, artifacts, and cleanup", 5),
+    ("Delivery workflow from task through review or PR", 5),
+    ("Agent guardrails and permission scoping", 10),
+    ("Context economy", 5),
+)
+FIX_RECORD_FIELDS = ("Problem", "Blocks", "Evidence", "Priority", "Owner", "Target", "Fix", "Verify", "Level")
+AREA_STATUSES = ("Verified", "Partial", "Repository-blocked", "N/A")
+
+
+def section(content: str, heading: str) -> str | None:
+    match = re.search(rf"^## {re.escape(heading)}\n(.*?)(?=^## |\Z)", content, re.MULTILINE | re.DOTALL)
+    return match.group(1) if match else None
+
+
+def yaml_block(content: str) -> str | None:
+    run_scope = section(content, "Run and Scope")
+    if run_scope is None:
+        return None
+    match = re.search(r"^```yaml\n(.*?)^```$", run_scope, re.MULTILINE | re.DOTALL)
+    return match.group(1) if match else None
+
+
+def integer(yaml: str, key: str, errors: list[str]) -> int | None:
+    match = re.search(rf"^{re.escape(key)}:\s*(\d+)\s*$", yaml, re.MULTILINE)
+    if not match:
+        errors.append(f"invalid Run and Scope integer: {key}")
+        return None
+    return int(match.group(1))
+
+
+def allowed_value(yaml: str, key: str, values: tuple[str, ...], errors: list[str]) -> None:
+    match = re.search(rf"^{re.escape(key)}:\s*(.+?)\s*$", yaml, re.MULTILINE)
+    if match and match.group(1) not in values:
+        errors.append(f"invalid Run and Scope {key}: {match.group(1)}")
+
+
+def validate_scorecard(content: str, errors: list[str]) -> tuple[dict[int, int], int, int]:
+    scorecard = section(content, "Readiness Scorecard")
+    scores: dict[int, int] = {}
+    total = 0
+    applicable_maximum = 0
+    if scorecard is None:
+        return scores, total, applicable_maximum
+
+    for number, (name, maximum) in enumerate(AREAS, start=1):
+        match = re.search(
+            rf"^\| {re.escape(name)} \| [^|]* \| ([^|]*) \| ([^|]*) \|",
+            scorecard,
+            re.MULTILINE,
+        )
+        if not match:
+            errors.append(f"missing scorecard row: {name}")
+            continue
+        status = match.group(1).strip()
+        score = match.group(2).strip()
+        if status not in AREA_STATUSES:
+            errors.append(f"invalid status for {name}: {status}")
+        expected = {
+            "Verified": maximum,
+            "Partial": maximum // 2,
+            "Repository-blocked": 0,
+        }.get(status)
+        if status == "N/A":
+            if score != "N/A":
+                errors.append(f"invalid score for {name}: {score}")
+            continue
+        applicable_maximum += maximum
+        if expected is None or score != f"{expected}/{maximum}":
+            errors.append(f"invalid score for {name}: {score}")
+            continue
+        scores[number] = expected
+        total += expected
+    return scores, total, applicable_maximum
+
+
+def validate_gates(yaml: str, scores: dict[int, int], errors: list[str]) -> None:
+    expected = {
+        "setup": (2,),
+        "deliverable": (3,),
+        "verification": (4, 5, 6),
+    }
+    for gate, anchors in expected.items():
+        match = re.search(
+            rf"^  {gate}:\n    anchor:\s*(\d+)\n    score:\s*(\d+)\s*$",
+            yaml,
+            re.MULTILINE,
+        )
+        if not match:
+            errors.append(f"missing gate entry: {gate}")
+            continue
+        anchor, score = (int(value) for value in match.groups())
+        if anchor not in anchors:
+            errors.append(f"invalid gate anchor: {gate}")
+            continue
+        if scores.get(anchor) != score:
+            errors.append(f"gate {gate} score does not match anchor area {anchor}")
+
+    if not re.search(r"^  probe:\n    result:\s*(pass|fail|not attempted)\s*$", yaml, re.MULTILINE):
+        errors.append("missing gate entry: probe")
+
+
+def validate_fix_records(content: str, errors: list[str]) -> None:
+    fixes = section(content, "What to Fix")
+    if fixes is None:
+        return
+    for identifier, record in re.findall(r"^### (F-\d\d)\n(.*?)(?=^### |\Z)", fixes, re.MULTILINE | re.DOTALL):
+        for field in FIX_RECORD_FIELDS:
+            if not re.search(rf"^\*\*{re.escape(field)}:\*\*\s+\S", record, re.MULTILINE):
+                errors.append(f"{identifier} is missing Fix Record field: {field}")
 
 
 def validate(path: Path) -> list[str]:
-    content = path.read_text(encoding="utf-8")
-    errors: list[str] = []
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError:
+        return [f"cannot read report: {path}"]
 
+    errors: list[str] = []
     if not re.search(r"^# Agentic Readiness — .+", content, re.MULTILINE):
         errors.append("missing report title")
 
     headings = re.findall(r"^## (.+)$", content, re.MULTILINE)
-    missing = [section for section in SECTIONS if section not in headings]
-    errors.extend(f"missing section: {section}" for section in missing)
+    missing = [heading for heading in SECTIONS if heading not in headings]
+    errors.extend(f"missing section: {heading}" for heading in missing)
     if not missing and tuple(headings) != SECTIONS:
         errors.append("sections are not in the required order")
 
-    glossary = re.search(r"^## Glossary\n(.*?)(?=^## |\Z)", content, re.MULTILINE | re.DOTALL)
-    if not glossary or "| Term | Meaning |" not in glossary.group(1):
+    glossary = section(content, "Glossary")
+    if glossary is None or not re.search(r"^\| Term \| Meaning \|$", glossary, re.MULTILINE):
         errors.append("missing glossary table header")
 
-    run_scope = re.search(
-        r"^## Run and Scope\n.*?^```yaml\n(.*?)^```",
-        content,
-        re.MULTILINE | re.DOTALL,
-    )
-    if not run_scope:
+    yaml = yaml_block(content)
+    if yaml is None:
         errors.append("missing Run and Scope YAML block")
     else:
-        yaml = run_scope.group(1)
         for key in RUN_KEYS:
             if not re.search(rf"^{re.escape(key)}:\s", yaml, re.MULTILINE):
                 errors.append(f"missing Run and Scope key: {key}")
+        allowed_value(yaml, "status", ("Ready", "Partially ready", "Not ready"), errors)
+        allowed_value(yaml, "confidence", ("High", "Medium", "Low"), errors)
+        scores, scorecard_total, scorecard_maximum = validate_scorecard(content, errors)
+        raw_total = integer(yaml, "raw_total", errors)
+        applicable_maximum = integer(yaml, "applicable_maximum", errors)
+        normalized_score = integer(yaml, "normalized_score", errors)
+        if raw_total is not None and raw_total != scorecard_total:
+            errors.append("raw_total does not equal scorecard total")
+        if applicable_maximum is not None and applicable_maximum != scorecard_maximum:
+            errors.append("applicable_maximum does not equal scorecard maximum")
+        if raw_total is not None and applicable_maximum not in (None, 0) and normalized_score is not None:
+            if normalized_score != round(raw_total / applicable_maximum * 100):
+                errors.append("normalized_score does not match raw_total and applicable_maximum")
+        validate_gates(yaml, scores, errors)
 
+    validate_fix_records(content, errors)
     return errors
 
 

--- a/skills/agentic-readiness-assessment/scripts/validate_report.py
+++ b/skills/agentic-readiness-assessment/scripts/validate_report.py
@@ -106,7 +106,7 @@ def allowed_value(yaml: str, key: str, values: tuple[str, ...], errors: list[str
         errors.append(f"invalid Run and Scope {key}: {match.group(1)}")
 
 
-def validate_scorecard(content: str, errors: list[str]) -> tuple[dict[int, int], dict[int, str], dict[int, int], int, int]:
+def validate_scorecard(content: str, errors: list[str]) -> tuple[dict[int, int], dict[int, str], dict[int, int], int, int, bool]:
     scorecard = section(content, "Readiness Scorecard")
     scores: dict[int, int] = {}
     statuses: dict[int, str] = {}
@@ -114,7 +114,7 @@ def validate_scorecard(content: str, errors: list[str]) -> tuple[dict[int, int],
     total = 0
     applicable_maximum = 0
     if scorecard is None:
-        return scores, statuses, maximums, total, applicable_maximum
+        return scores, statuses, maximums, total, applicable_maximum, False
 
     for number, (name, maximum) in enumerate(AREAS, start=1):
         match = re.search(
@@ -146,7 +146,18 @@ def validate_scorecard(content: str, errors: list[str]) -> tuple[dict[int, int],
             continue
         scores[number] = expected
         total += expected
-    return scores, statuses, maximums, total, applicable_maximum
+    negative_controls = re.search(r"^Negative controls:\s*(.+?)\s*$", scorecard, re.MULTILINE)
+    if negative_controls is None:
+        errors.append("missing negative controls declaration")
+        has_negative_control = False
+    elif negative_controls.group(1) == "none":
+        has_negative_control = False
+    elif re.fullmatch(r"F-\d\d(?:, F-\d\d)*", negative_controls.group(1)):
+        has_negative_control = True
+    else:
+        errors.append("invalid negative controls declaration")
+        has_negative_control = False
+    return scores, statuses, maximums, total, applicable_maximum, has_negative_control
 
 
 def validate_gates(yaml: str, scores: dict[int, int], errors: list[str]) -> tuple[dict[str, int], str | None]:
@@ -179,28 +190,35 @@ def validate_gates(yaml: str, scores: dict[int, int], errors: list[str]) -> tupl
     return gate_anchors, probe.group(1) if probe else None
 
 
-def validate_overall_status(yaml: str, normalized_score: int | None, scores: dict[int, int], statuses: dict[int, str], maximums: dict[int, int], gate_anchors: dict[str, int], probe: str | None, errors: list[str]) -> None:
+def validate_overall_status(yaml: str, normalized_score: int | None, scores: dict[int, int], statuses: dict[int, str], maximums: dict[int, int], gate_anchors: dict[str, int], probe: str | None, has_p0: bool, has_negative_control: bool, errors: list[str]) -> None:
     status = re.search(r"^status:\s*(.+?)\s*$", yaml, re.MULTILINE)
     confidence = re.search(r"^confidence:\s*(.+?)\s*$", yaml, re.MULTILINE)
     if not status:
         return
-    if status.group(1) == "Ready":
-        gates_pass = all(
-            statuses.get(anchor) == "Verified" and scores.get(anchor) == maximums.get(anchor)
-            for anchor in gate_anchors.values()
-        ) and len(gate_anchors) == 3
-        if normalized_score is None or normalized_score < 80 or confidence is None or confidence.group(1) not in ("High", "Medium") or probe != "pass" or not gates_pass:
-            errors.append("Ready status is not supported by parsed report fields")
-    elif status.group(1) == "Partially ready":
-        gate_blocked = any(statuses.get(anchor) == "Repository-blocked" for anchor in gate_anchors.values())
-        if normalized_score is not None and (normalized_score < 50 or gate_blocked or probe == "fail"):
-            errors.append("Partially ready status is not supported by parsed report fields")
+    gates_pass = all(
+        statuses.get(anchor) == "Verified" and scores.get(anchor) == maximums.get(anchor)
+        for anchor in gate_anchors.values()
+    ) and len(gate_anchors) == 3
+    gate_blocked = any(statuses.get(anchor) == "Repository-blocked" for anchor in gate_anchors.values())
+    ready = normalized_score is not None and normalized_score >= 80 and confidence is not None and confidence.group(1) in ("High", "Medium") and probe == "pass" and gates_pass and not has_p0 and not has_negative_control
+    not_ready = normalized_score is not None and (normalized_score < 50 or gate_blocked or probe == "fail" or has_p0)
+
+    if status.group(1) == "Ready" and not ready:
+        errors.append("Ready status is not supported by parsed report fields")
+    elif status.group(1) == "Partially ready" and (ready or not_ready):
+        errors.append("Partially ready status is not supported by parsed report fields")
+    elif status.group(1) == "Not ready" and not not_ready:
+        errors.append("Not ready status is not supported by parsed report fields")
 
 
-def validate_fix_records(content: str, errors: list[str]) -> None:
+def split_table_row(row: str) -> list[str]:
+    return re.split(r"(?<!\\)\|", row)
+
+
+def validate_fix_records(content: str, errors: list[str]) -> bool:
     fixes = section(content, "What to Fix")
     if fixes is None:
-        return
+        return False
 
     normalized_fixes = fixes.strip()
     if not normalized_fixes.startswith(INDEX_HEADER):
@@ -222,7 +240,7 @@ def validate_fix_records(content: str, errors: list[str]) -> None:
 
     index_ids: list[str] = []
     for row in index_rows:
-        cells = row.split("|")
+        cells = split_table_row(row)
         if len(cells) != 7 or not row.endswith("|"):
             errors.append("malformed What to Fix compact index row")
             continue
@@ -257,6 +275,7 @@ def validate_fix_records(content: str, errors: list[str]) -> None:
         for field in FIX_RECORD_FIELDS:
             if not re.search(rf"^\*\*{re.escape(field)}:\*\*\s+\S", record, re.MULTILINE):
                 errors.append(f"{identifier} is missing Fix Record field: {field}")
+    return any(re.search(r"^\| F-\d\d \| P0 /", row) for row in index_rows)
 
 
 def validate(path: Path) -> list[str]:
@@ -277,15 +296,20 @@ def validate(path: Path) -> list[str]:
 
     glossary = section(content, "Glossary")
     normalized_glossary = glossary.strip() if glossary is not None else ""
-    anchor_sentence = r"Gate 3 anchor: Area [456] — [^\n]+\."
+    anchor_sentence = r"Gate 3 anchor: Area ([456]) — [^\n]+\."
+    glossary_anchor: int | None = None
     if glossary is None or not re.search(r"^\| Term \| Meaning \|$", normalized_glossary, re.MULTILINE):
         errors.append("missing glossary table header")
     elif not normalized_glossary.startswith(GLOSSARY_TABLE):
         errors.append("glossary does not match the fixed table")
     elif not normalized_glossary[len(GLOSSARY_TABLE):].strip():
         errors.append("missing Gate 3 anchor sentence")
-    elif not re.fullmatch(rf"{re.escape(GLOSSARY_TABLE)}\n\n{anchor_sentence}", normalized_glossary):
-        errors.append("glossary does not match the fixed contract")
+    else:
+        anchor = re.fullmatch(rf"{re.escape(GLOSSARY_TABLE)}\n\n{anchor_sentence}", normalized_glossary)
+        if not anchor:
+            errors.append("glossary does not match the fixed contract")
+        else:
+            glossary_anchor = int(anchor.group(1))
 
     yaml = yaml_block(content)
     if yaml is None:
@@ -299,7 +323,7 @@ def validate(path: Path) -> list[str]:
             errors.append("Run and Scope keys are not in the required order")
         allowed_value(yaml, "status", ("Ready", "Partially ready", "Not ready"), errors)
         allowed_value(yaml, "confidence", ("High", "Medium", "Low"), errors)
-        scores, area_statuses, area_maximums, scorecard_total, scorecard_maximum = validate_scorecard(content, errors)
+        scores, area_statuses, area_maximums, scorecard_total, scorecard_maximum, has_negative_control = validate_scorecard(content, errors)
         raw_total = integer(yaml, "raw_total", errors)
         applicable_maximum = integer(yaml, "applicable_maximum", errors)
         normalized_score = integer(yaml, "normalized_score", errors)
@@ -311,7 +335,11 @@ def validate(path: Path) -> list[str]:
             if normalized_score != round(raw_total / applicable_maximum * 100):
                 errors.append("normalized_score does not match raw_total and applicable_maximum")
         gate_anchors, probe = validate_gates(yaml, scores, errors)
-        validate_overall_status(yaml, normalized_score, scores, area_statuses, area_maximums, gate_anchors, probe, errors)
+        if glossary_anchor is not None and gate_anchors.get("verification") != glossary_anchor:
+            errors.append("Glossary Gate 3 anchor does not match gates.verification.anchor")
+        has_p0 = validate_fix_records(content, errors)
+        validate_overall_status(yaml, normalized_score, scores, area_statuses, area_maximums, gate_anchors, probe, has_p0, has_negative_control, errors)
+        return errors
 
     validate_fix_records(content, errors)
     return errors

--- a/skills/agentic-readiness-assessment/scripts/validate_report.py
+++ b/skills/agentic-readiness-assessment/scripts/validate_report.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+SECTIONS = (
+    "Verdict",
+    "Run and Scope",
+    "Glossary",
+    "Readiness Scorecard",
+    "Mandatory Gates",
+    "What to Fix",
+    "What Can Be Delegated Today",
+    "What Is Already Good",
+    "Surface Resolution",
+    "Golden Path",
+    "Probe",
+    "Commands Executed",
+    "Confidence and Limits",
+)
+RUN_KEYS = (
+    "audited_by",
+    "prompt_version",
+    "started",
+    "completed",
+    "commit",
+    "branch",
+    "platform",
+    "archetype",
+    "scope",
+    "baseline_worktree",
+    "final_worktree",
+    "clean_state_setup",
+    "normalized_score",
+    "raw_total",
+    "applicable_maximum",
+    "status",
+    "confidence",
+    "gates",
+)
+
+
+def validate(path: Path) -> list[str]:
+    content = path.read_text(encoding="utf-8")
+    errors: list[str] = []
+
+    if not re.search(r"^# Agentic Readiness — .+", content, re.MULTILINE):
+        errors.append("missing report title")
+
+    headings = re.findall(r"^## (.+)$", content, re.MULTILINE)
+    missing = [section for section in SECTIONS if section not in headings]
+    errors.extend(f"missing section: {section}" for section in missing)
+    if not missing and tuple(headings) != SECTIONS:
+        errors.append("sections are not in the required order")
+
+    glossary = re.search(r"^## Glossary\n(.*?)(?=^## |\Z)", content, re.MULTILINE | re.DOTALL)
+    if not glossary or "| Term | Meaning |" not in glossary.group(1):
+        errors.append("missing glossary table header")
+
+    run_scope = re.search(
+        r"^## Run and Scope\n.*?^```yaml\n(.*?)^```",
+        content,
+        re.MULTILINE | re.DOTALL,
+    )
+    if not run_scope:
+        errors.append("missing Run and Scope YAML block")
+    else:
+        yaml = run_scope.group(1)
+        for key in RUN_KEYS:
+            if not re.search(rf"^{re.escape(key)}:\s", yaml, re.MULTILINE):
+                errors.append(f"missing Run and Scope key: {key}")
+
+    return errors
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Validate an agentic-readiness report contract.")
+    parser.add_argument("report", type=Path)
+    args = parser.parse_args(argv)
+
+    errors = validate(args.report)
+    if errors:
+        print("\n".join(errors), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/agentic-readiness-assessment/scripts/validate_report.py
+++ b/skills/agentic-readiness-assessment/scripts/validate_report.py
@@ -58,6 +58,8 @@ AREAS = (
 )
 FIX_RECORD_FIELDS = ("Problem", "Blocks", "Evidence", "Priority", "Owner", "Target", "Fix", "Verify", "Level")
 AREA_STATUSES = ("Verified", "Partial", "Repository-blocked", "N/A")
+INDEX_HEADER = "| ID | Priority / Owner | Problem and blocked capability | Fix and target | Verify |"
+INDEX_SEPARATOR = "| --- | --- | --- | --- | --- |"
 GLOSSARY_TABLE = """| Term | Meaning |
 |---|---|
 | Area | One of 14 scored readiness dimensions. Each has a weight shown as `Max`. |
@@ -104,13 +106,15 @@ def allowed_value(yaml: str, key: str, values: tuple[str, ...], errors: list[str
         errors.append(f"invalid Run and Scope {key}: {match.group(1)}")
 
 
-def validate_scorecard(content: str, errors: list[str]) -> tuple[dict[int, int], int, int]:
+def validate_scorecard(content: str, errors: list[str]) -> tuple[dict[int, int], dict[int, str], dict[int, int], int, int]:
     scorecard = section(content, "Readiness Scorecard")
     scores: dict[int, int] = {}
+    statuses: dict[int, str] = {}
+    maximums: dict[int, int] = {}
     total = 0
     applicable_maximum = 0
     if scorecard is None:
-        return scores, total, applicable_maximum
+        return scores, statuses, maximums, total, applicable_maximum
 
     for number, (name, maximum) in enumerate(AREAS, start=1):
         match = re.search(
@@ -123,6 +127,8 @@ def validate_scorecard(content: str, errors: list[str]) -> tuple[dict[int, int],
             continue
         status = match.group(1).strip()
         score = match.group(2).strip()
+        statuses[number] = status
+        maximums[number] = maximum
         if status not in AREA_STATUSES:
             errors.append(f"invalid status for {name}: {status}")
         expected = {
@@ -140,15 +146,16 @@ def validate_scorecard(content: str, errors: list[str]) -> tuple[dict[int, int],
             continue
         scores[number] = expected
         total += expected
-    return scores, total, applicable_maximum
+    return scores, statuses, maximums, total, applicable_maximum
 
 
-def validate_gates(yaml: str, scores: dict[int, int], errors: list[str]) -> None:
+def validate_gates(yaml: str, scores: dict[int, int], errors: list[str]) -> tuple[dict[str, int], str | None]:
     expected = {
         "setup": (2,),
         "deliverable": (3,),
         "verification": (4, 5, 6),
     }
+    gate_anchors: dict[str, int] = {}
     for gate, anchors in expected.items():
         match = re.search(
             rf"^  {gate}:\n    anchor:\s*(\d+)\n    score:\s*(\d+)\s*$",
@@ -162,11 +169,32 @@ def validate_gates(yaml: str, scores: dict[int, int], errors: list[str]) -> None
         if anchor not in anchors:
             errors.append(f"invalid gate anchor: {gate}")
             continue
+        gate_anchors[gate] = anchor
         if scores.get(anchor) != score:
             errors.append(f"gate {gate} score does not match anchor area {anchor}")
 
-    if not re.search(r"^  probe:\n    result:\s*(pass|fail|not attempted)\s*$", yaml, re.MULTILINE):
+    probe = re.search(r"^  probe:\n    result:\s*(pass|fail|not attempted)\s*$", yaml, re.MULTILINE)
+    if not probe:
         errors.append("missing gate entry: probe")
+    return gate_anchors, probe.group(1) if probe else None
+
+
+def validate_overall_status(yaml: str, normalized_score: int | None, scores: dict[int, int], statuses: dict[int, str], maximums: dict[int, int], gate_anchors: dict[str, int], probe: str | None, errors: list[str]) -> None:
+    status = re.search(r"^status:\s*(.+?)\s*$", yaml, re.MULTILINE)
+    confidence = re.search(r"^confidence:\s*(.+?)\s*$", yaml, re.MULTILINE)
+    if not status:
+        return
+    if status.group(1) == "Ready":
+        gates_pass = all(
+            statuses.get(anchor) == "Verified" and scores.get(anchor) == maximums.get(anchor)
+            for anchor in gate_anchors.values()
+        ) and len(gate_anchors) == 3
+        if normalized_score is None or normalized_score < 80 or confidence is None or confidence.group(1) not in ("High", "Medium") or probe != "pass" or not gates_pass:
+            errors.append("Ready status is not supported by parsed report fields")
+    elif status.group(1) == "Partially ready":
+        gate_blocked = any(statuses.get(anchor) == "Repository-blocked" for anchor in gate_anchors.values())
+        if normalized_score is not None and (normalized_score < 50 or gate_blocked or probe == "fail"):
+            errors.append("Partially ready status is not supported by parsed report fields")
 
 
 def validate_fix_records(content: str, errors: list[str]) -> None:
@@ -174,9 +202,31 @@ def validate_fix_records(content: str, errors: list[str]) -> None:
     if fixes is None:
         return
 
-    index = fixes.split("\n### ", 1)[0]
+    normalized_fixes = fixes.strip()
+    if not normalized_fixes.startswith(INDEX_HEADER):
+        errors.append("missing What to Fix compact index")
+        index_rows: list[str] = []
+    else:
+        after_header = normalized_fixes[len(INDEX_HEADER):]
+        if not after_header.startswith(f"\n{INDEX_SEPARATOR}"):
+            errors.append("malformed What to Fix compact index separator")
+            index_rows = []
+        else:
+            index_rows = []
+            for line in after_header[len(INDEX_SEPARATOR) + 2:].splitlines():
+                if not line:
+                    break
+                if not line.startswith("|"):
+                    break
+                index_rows.append(line)
+
     index_ids: list[str] = []
-    for value in re.findall(r"^\|\s*(F-[^| ]*)\s*\|", index, re.MULTILINE):
+    for row in index_rows:
+        cells = row.split("|")
+        if len(cells) != 7 or not row.endswith("|"):
+            errors.append("malformed What to Fix compact index row")
+            continue
+        value = cells[1].strip()
         if not re.fullmatch(r"F-\d\d", value):
             errors.append(f"malformed Fix Record index ID: {value}")
         else:
@@ -227,12 +277,15 @@ def validate(path: Path) -> list[str]:
 
     glossary = section(content, "Glossary")
     normalized_glossary = glossary.strip() if glossary is not None else ""
+    anchor_sentence = r"Gate 3 anchor: Area [456] — [^\n]+\."
     if glossary is None or not re.search(r"^\| Term \| Meaning \|$", normalized_glossary, re.MULTILINE):
         errors.append("missing glossary table header")
     elif not normalized_glossary.startswith(GLOSSARY_TABLE):
         errors.append("glossary does not match the fixed table")
-    elif not re.search(r"^Gate 3 anchor: Area [456] — .+\.$", normalized_glossary[len(GLOSSARY_TABLE):].strip(), re.MULTILINE):
+    elif not normalized_glossary[len(GLOSSARY_TABLE):].strip():
         errors.append("missing Gate 3 anchor sentence")
+    elif not re.fullmatch(rf"{re.escape(GLOSSARY_TABLE)}\n\n{anchor_sentence}", normalized_glossary):
+        errors.append("glossary does not match the fixed contract")
 
     yaml = yaml_block(content)
     if yaml is None:
@@ -246,7 +299,7 @@ def validate(path: Path) -> list[str]:
             errors.append("Run and Scope keys are not in the required order")
         allowed_value(yaml, "status", ("Ready", "Partially ready", "Not ready"), errors)
         allowed_value(yaml, "confidence", ("High", "Medium", "Low"), errors)
-        scores, scorecard_total, scorecard_maximum = validate_scorecard(content, errors)
+        scores, area_statuses, area_maximums, scorecard_total, scorecard_maximum = validate_scorecard(content, errors)
         raw_total = integer(yaml, "raw_total", errors)
         applicable_maximum = integer(yaml, "applicable_maximum", errors)
         normalized_score = integer(yaml, "normalized_score", errors)
@@ -257,7 +310,8 @@ def validate(path: Path) -> list[str]:
         if raw_total is not None and applicable_maximum not in (None, 0) and normalized_score is not None:
             if normalized_score != round(raw_total / applicable_maximum * 100):
                 errors.append("normalized_score does not match raw_total and applicable_maximum")
-        validate_gates(yaml, scores, errors)
+        gate_anchors, probe = validate_gates(yaml, scores, errors)
+        validate_overall_status(yaml, normalized_score, scores, area_statuses, area_maximums, gate_anchors, probe, errors)
 
     validate_fix_records(content, errors)
     return errors

--- a/skills/agentic-readiness-assessment/scripts/validate_report.py
+++ b/skills/agentic-readiness-assessment/scripts/validate_report.py
@@ -58,6 +58,23 @@ AREAS = (
 )
 FIX_RECORD_FIELDS = ("Problem", "Blocks", "Evidence", "Priority", "Owner", "Target", "Fix", "Verify", "Level")
 AREA_STATUSES = ("Verified", "Partial", "Repository-blocked", "N/A")
+GLOSSARY_TABLE = """| Term | Meaning |
+|---|---|
+| Area | One of 14 scored readiness dimensions. Each has a weight shown as `Max`. |
+| Gate | One of 4 mandatory checks. A gate's result **is** its anchor area's score, not a separate number. Gates 1–3 pass only at full points. |
+| Probe | Gate 4. A deliberate small defect introduced and reverted, to test whether the repository's own verification catches a real break. |
+| `F-nn` | A Fix Record: one stable ID per problem, holding the finding and its fix together. |
+| Priority | P0 stops unattended work and needs a human. P1 lets the agent proceed incorrectly or unvalidated. P2 costs avoidable time or clarity. |
+| Owner | Who fixes it: `repo`, `agent-environment` (the agent's image or toolchain), `platform` (org or infra config), or `external-service`. |
+| Readiness status | Per area: Verified (full points), Partial (half, rounded down), Repository-blocked (0), or N/A (excluded from the maximum). |
+| Verification state | How the evidence was obtained: Executed, Executed (unfrozen fallback), CI-proven, Environment-blocked, Not run: unsafe, or Not applicable. |
+| Level | What a fix changes: `code`, `control`, `docs`, or `instructions`. |
+| Normalized score | `points earned / applicable maximum * 100`. The applicable maximum is 105 minus the weight of every N/A area, so it is rarely 100. |
+| Repository blocker | The repository itself is missing, wrong, unsafe, or contradictory. Counts against readiness. |
+| Environment blocker | The repository documents enough, but this audit machine lacked a tool, service, or permission. Caps confidence; never a full zero. |
+| Enforced control | Something that actually fails when violated. A rule that lives only in prose is documented guidance, not an enforced control. |
+| Negative control | A safety defect such as a permission bypass, allow-all policy, unguarded secret file, or committed plaintext credential. Caps area 13 at 2. |
+| Unfrozen fallback | The locked install failed, so a non-mutating unlocked install was used instead. Valid evidence, but caps the setup area at half. |"""
 
 
 def section(content: str, heading: str) -> str | None:
@@ -156,7 +173,37 @@ def validate_fix_records(content: str, errors: list[str]) -> None:
     fixes = section(content, "What to Fix")
     if fixes is None:
         return
-    for identifier, record in re.findall(r"^### (F-\d\d)\n(.*?)(?=^### |\Z)", fixes, re.MULTILINE | re.DOTALL):
+
+    index = fixes.split("\n### ", 1)[0]
+    index_ids: list[str] = []
+    for value in re.findall(r"^\|\s*(F-[^| ]*)\s*\|", index, re.MULTILINE):
+        if not re.fullmatch(r"F-\d\d", value):
+            errors.append(f"malformed Fix Record index ID: {value}")
+        else:
+            index_ids.append(value)
+    for identifier in set(index_ids):
+        if index_ids.count(identifier) != 1:
+            errors.append(f"duplicate Fix Record index ID: {identifier}")
+
+    records: list[tuple[str, str]] = []
+    declarations = list(re.finditer(r"^### (F-.*)$", fixes, re.MULTILINE))
+    for position, declaration in enumerate(declarations):
+        identifier = declaration.group(1)
+        if not re.fullmatch(r"F-\d\d", identifier):
+            errors.append(f"malformed Fix Record declaration: {identifier}")
+            continue
+        end = declarations[position + 1].start() if position + 1 < len(declarations) else len(fixes)
+        records.append((identifier, fixes[declaration.end():end]))
+
+    record_ids = [identifier for identifier, _ in records]
+    for identifier in set(index_ids):
+        if record_ids.count(identifier) != 1:
+            errors.append(f"index Fix Record {identifier} does not have exactly one matching record")
+    for identifier in set(record_ids):
+        if identifier not in index_ids:
+            errors.append(f"Fix Record {identifier} is not declared in the index")
+
+    for identifier, record in records:
         for field in FIX_RECORD_FIELDS:
             if not re.search(rf"^\*\*{re.escape(field)}:\*\*\s+\S", record, re.MULTILINE):
                 errors.append(f"{identifier} is missing Fix Record field: {field}")
@@ -179,16 +226,24 @@ def validate(path: Path) -> list[str]:
         errors.append("sections are not in the required order")
 
     glossary = section(content, "Glossary")
-    if glossary is None or not re.search(r"^\| Term \| Meaning \|$", glossary, re.MULTILINE):
+    normalized_glossary = glossary.strip() if glossary is not None else ""
+    if glossary is None or not re.search(r"^\| Term \| Meaning \|$", normalized_glossary, re.MULTILINE):
         errors.append("missing glossary table header")
+    elif not normalized_glossary.startswith(GLOSSARY_TABLE):
+        errors.append("glossary does not match the fixed table")
+    elif not re.search(r"^Gate 3 anchor: Area [456] — .+\.$", normalized_glossary[len(GLOSSARY_TABLE):].strip(), re.MULTILINE):
+        errors.append("missing Gate 3 anchor sentence")
 
     yaml = yaml_block(content)
     if yaml is None:
         errors.append("missing Run and Scope YAML block")
     else:
+        top_level_keys = tuple(re.findall(r"^([a-z_]+):", yaml, re.MULTILINE))
         for key in RUN_KEYS:
             if not re.search(rf"^{re.escape(key)}:\s", yaml, re.MULTILINE):
                 errors.append(f"missing Run and Scope key: {key}")
+        if top_level_keys != RUN_KEYS:
+            errors.append("Run and Scope keys are not in the required order")
         allowed_value(yaml, "status", ("Ready", "Partially ready", "Not ready"), errors)
         allowed_value(yaml, "confidence", ("High", "Medium", "Low"), errors)
         scores, scorecard_total, scorecard_maximum = validate_scorecard(content, errors)

--- a/skills/agentic-readiness-assessment/tests/test_validate_report.py
+++ b/skills/agentic-readiness-assessment/tests/test_validate_report.py
@@ -24,10 +24,29 @@ SECTIONS = (
     "Commands Executed",
     "Confidence and Limits",
 )
+AREAS = (
+    ("Agent guidance and navigation", 10),
+    ("Reproducible environment and dependency setup", 10),
+    ("Build, package, render, or deliverable validation", 10),
+    ("Lint, format check, typecheck, static analysis, or policy validation", 10),
+    ("Unit or component tests", 10),
+    ("Integration, contract, or functional tests", 5),
+    ("Runtime, API, CLI, or local-preview validation", 5),
+    ("Browser or UI validation", 5),
+    ("Coverage and feedback-loop quality", 5),
+    ("CI enforcement and parity with local validation", 10),
+    ("Safety, test isolation, artifacts, and cleanup", 5),
+    ("Delivery workflow from task through review or PR", 5),
+    ("Agent guardrails and permission scoping", 10),
+    ("Context economy", 5),
+)
+FIX_FIELDS = ("Problem", "Blocks", "Evidence", "Priority", "Owner", "Target", "Fix", "Verify", "Level")
 
-RUN_SCOPE = """```yaml
+
+def run_scope(*, raw_total: int = 105, normalized_score: int = 100, setup_score: int = 10) -> str:
+    return f"""```yaml
 audited_by: agent
-prompt_version: 4.2.0
+prompt_version: 4.4.0
 started: now
 completed: now
 commit: abc123
@@ -38,26 +57,53 @@ scope: repository
 baseline_worktree: clean
 final_worktree: clean
 clean_state_setup: verified
-normalized_score: 100
-raw_total: 105
+normalized_score: {normalized_score}
+raw_total: {raw_total}
 applicable_maximum: 105
 status: Ready
 confidence: High
 gates:
-  setup: pass
-  deliverable: pass
-  verification: pass
-  probe: pass
+  setup:
+    anchor: 2
+    score: {setup_score}
+  deliverable:
+    anchor: 3
+    score: 10
+  verification:
+    anchor: 5
+    score: 10
+  probe:
+    result: pass
 ```"""
 
 
-def report(*, sections: tuple[str, ...] = SECTIONS, run_scope: str = RUN_SCOPE) -> str:
+def scorecard(*, setup_status: str = "Verified") -> str:
+    rows = ["| Area | Applicability | Status | Score | Verification | Evidence / Result | Fix IDs |"]
+    rows.append("| --- | --- | --- | --- | --- | --- | --- |")
+    for name, maximum in AREAS:
+        status = setup_status if name == "Reproducible environment and dependency setup" else "Verified"
+        score = maximum if status == "Verified" else maximum // 2
+        rows.append(f"| {name} | applicable | {status} | {score}/{maximum} | Executed | evidence | |")
+    return "\n".join(rows)
+
+
+def fix_records(*, complete: bool = True) -> str:
+    fields = FIX_FIELDS if complete else FIX_FIELDS[:-1]
+    body = ["| ID | Priority / Owner | Problem and blocked capability | Fix and target | Verify |", "| --- | --- | --- | --- | --- |", "| F-01 | P2 / repo | problem | fix | command |", "", "### F-01"]
+    body.extend(f"**{field}:** value" for field in fields)
+    return "\n".join(body)
+
+
+def report(*, sections: tuple[str, ...] = SECTIONS, run_scope_body: str | None = None, glossary: str = "| Term | Meaning |\n| --- | --- |", scorecard_body: str | None = None, fixes: str | None = None) -> str:
+    bodies = {
+        "Run and Scope": run_scope() if run_scope_body is None else run_scope_body,
+        "Glossary": glossary,
+        "Readiness Scorecard": scorecard() if scorecard_body is None else scorecard_body,
+        "What to Fix": fix_records() if fixes is None else fixes,
+    }
     parts = ["# Agentic Readiness — Example"]
     for section in sections:
-        body = "| Term | Meaning |\n| --- | --- |" if section == "Glossary" else "Content"
-        if section == "Run and Scope":
-            body = run_scope
-        parts.append(f"## {section}\n\n{body}")
+        parts.append(f"## {section}\n\n{bodies.get(section, 'Content')}")
     return "\n\n".join(parts)
 
 
@@ -73,24 +119,49 @@ class ValidateReportTests(unittest.TestCase):
 
     def test_rejects_a_missing_required_section(self) -> None:
         sections = tuple(section for section in SECTIONS if section != "Probe")
-
         self.assertIn("missing section: Probe", self.validate(report(sections=sections)))
 
     def test_rejects_sections_out_of_order(self) -> None:
         sections = list(SECTIONS)
         sections[0], sections[1] = sections[1], sections[0]
-
         self.assertIn("sections are not in the required order", self.validate(report(sections=tuple(sections))))
 
-    def test_rejects_a_missing_glossary_header(self) -> None:
-        malformed = report().replace("| Term | Meaning |", "Glossary")
+    def test_rejects_an_unreadable_report(self) -> None:
+        errors = validate_report.validate(Path("does-not-exist.md"))
+        self.assertEqual(errors, ["cannot read report: does-not-exist.md"])
 
-        self.assertIn("missing glossary table header", self.validate(malformed))
+    def test_rejects_glossary_text_that_is_not_a_header_row(self) -> None:
+        errors = self.validate(report(glossary="The required header is | Term | Meaning |."))
+        self.assertIn("missing glossary table header", errors)
 
-    def test_rejects_a_missing_run_scope_key(self) -> None:
-        run_scope = RUN_SCOPE.replace("prompt_version: 4.2.0\n", "")
+    def test_rejects_a_yaml_block_outside_run_and_scope(self) -> None:
+        malformed = report(run_scope_body="Content").replace("## Confidence and Limits\n\nContent", f"## Confidence and Limits\n\n{run_scope()}")
+        self.assertIn("missing Run and Scope YAML block", self.validate(malformed))
 
-        self.assertIn("missing Run and Scope key: prompt_version", self.validate(report(run_scope=run_scope)))
+    def test_rejects_a_missing_gate_map_entry(self) -> None:
+        malformed = run_scope().replace("  probe:\n    result: pass\n", "")
+        self.assertIn("missing gate entry: probe", self.validate(report(run_scope_body=malformed)))
+
+    def test_rejects_score_arithmetic_that_does_not_match_scorecard(self) -> None:
+        errors = self.validate(report(run_scope_body=run_scope(raw_total=104, normalized_score=100)))
+        self.assertIn("raw_total does not equal scorecard total", errors)
+        self.assertIn("normalized_score does not match raw_total and applicable_maximum", errors)
+
+    def test_rejects_an_invalid_area_status_and_score(self) -> None:
+        errors = self.validate(report(scorecard_body=scorecard(setup_status="Ready")))
+        self.assertIn("invalid status for Reproducible environment and dependency setup: Ready", errors)
+        self.assertIn("invalid score for Reproducible environment and dependency setup: 5/10", errors)
+
+    def test_rejects_a_gate_score_that_does_not_match_its_anchor(self) -> None:
+        errors = self.validate(report(run_scope_body=run_scope(setup_score=5)))
+        self.assertIn("gate setup score does not match anchor area 2", errors)
+
+    def test_rejects_an_invalid_overall_status(self) -> None:
+        errors = self.validate(report(run_scope_body=run_scope().replace("status: Ready", "status: Unknown")))
+        self.assertIn("invalid Run and Scope status: Unknown", errors)
+
+    def test_rejects_an_incomplete_fix_record(self) -> None:
+        self.assertIn("F-01 is missing Fix Record field: Level", self.validate(report(fixes=fix_records(complete=False))))
 
 
 if __name__ == "__main__":

--- a/skills/agentic-readiness-assessment/tests/test_validate_report.py
+++ b/skills/agentic-readiness-assessment/tests/test_validate_report.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parents[1] / "scripts"))
+import validate_report
+
+
+SECTIONS = (
+    "Verdict",
+    "Run and Scope",
+    "Glossary",
+    "Readiness Scorecard",
+    "Mandatory Gates",
+    "What to Fix",
+    "What Can Be Delegated Today",
+    "What Is Already Good",
+    "Surface Resolution",
+    "Golden Path",
+    "Probe",
+    "Commands Executed",
+    "Confidence and Limits",
+)
+
+RUN_SCOPE = """```yaml
+audited_by: agent
+prompt_version: 4.2.0
+started: now
+completed: now
+commit: abc123
+branch: main
+platform: test
+archetype: documentation
+scope: repository
+baseline_worktree: clean
+final_worktree: clean
+clean_state_setup: verified
+normalized_score: 100
+raw_total: 105
+applicable_maximum: 105
+status: Ready
+confidence: High
+gates:
+  setup: pass
+  deliverable: pass
+  verification: pass
+  probe: pass
+```"""
+
+
+def report(*, sections: tuple[str, ...] = SECTIONS, run_scope: str = RUN_SCOPE) -> str:
+    parts = ["# Agentic Readiness — Example"]
+    for section in sections:
+        body = "| Term | Meaning |\n| --- | --- |" if section == "Glossary" else "Content"
+        if section == "Run and Scope":
+            body = run_scope
+        parts.append(f"## {section}\n\n{body}")
+    return "\n\n".join(parts)
+
+
+class ValidateReportTests(unittest.TestCase):
+    def validate(self, content: str) -> list[str]:
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "agentic-readiness.md"
+            path.write_text(content, encoding="utf-8")
+            return validate_report.validate(path)
+
+    def test_accepts_a_report_with_the_required_contract(self) -> None:
+        self.assertEqual(self.validate(report()), [])
+
+    def test_rejects_a_missing_required_section(self) -> None:
+        sections = tuple(section for section in SECTIONS if section != "Probe")
+
+        self.assertIn("missing section: Probe", self.validate(report(sections=sections)))
+
+    def test_rejects_sections_out_of_order(self) -> None:
+        sections = list(SECTIONS)
+        sections[0], sections[1] = sections[1], sections[0]
+
+        self.assertIn("sections are not in the required order", self.validate(report(sections=tuple(sections))))
+
+    def test_rejects_a_missing_glossary_header(self) -> None:
+        malformed = report().replace("| Term | Meaning |", "Glossary")
+
+        self.assertIn("missing glossary table header", self.validate(malformed))
+
+    def test_rejects_a_missing_run_scope_key(self) -> None:
+        run_scope = RUN_SCOPE.replace("prompt_version: 4.2.0\n", "")
+
+        self.assertIn("missing Run and Scope key: prompt_version", self.validate(report(run_scope=run_scope)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/agentic-readiness-assessment/tests/test_validate_report.py
+++ b/skills/agentic-readiness-assessment/tests/test_validate_report.py
@@ -103,6 +103,7 @@ def scorecard(*, setup_status: str = "Verified") -> str:
         status = setup_status if name == "Reproducible environment and dependency setup" else "Verified"
         score = maximum if status == "Verified" else maximum // 2
         rows.append(f"| {name} | applicable | {status} | {score}/{maximum} | Executed | evidence | |")
+    rows.extend(("", "Negative controls: none"))
     return "\n".join(rows)
 
 
@@ -189,6 +190,28 @@ class ValidateReportTests(unittest.TestCase):
     def test_rejects_a_gate_score_that_does_not_match_its_anchor(self) -> None:
         errors = self.validate(report(run_scope_body=run_scope(setup_score=5)))
         self.assertIn("gate setup score does not match anchor area 2", errors)
+
+    def test_rejects_a_glossary_gate_three_anchor_that_differs_from_the_gate_map(self) -> None:
+        errors = self.validate(report(glossary=GLOSSARY.replace("Area 5 —", "Area 4 —")))
+        self.assertIn("Glossary Gate 3 anchor does not match gates.verification.anchor", errors)
+
+    def test_accepts_an_escaped_pipe_in_a_compact_index_row(self) -> None:
+        fixes = fix_records().replace("| F-01 | P2 / repo | problem | fix | command |", "| F-01 | P2 / repo | command \\| pipeline | fix | command |")
+        self.assertEqual(self.validate(report(fixes=fixes)), [])
+
+    def test_rejects_ready_with_a_p0_fix_record(self) -> None:
+        fixes = fix_records().replace("P2 / repo", "P0 / repo")
+        errors = self.validate(report(fixes=fixes))
+        self.assertIn("Ready status is not supported by parsed report fields", errors)
+
+    def test_rejects_ready_with_a_negative_control(self) -> None:
+        scorecard_with_negative_control = scorecard().replace("Negative controls: none", "Negative controls: F-01")
+        errors = self.validate(report(scorecard_body=scorecard_with_negative_control))
+        self.assertIn("Ready status is not supported by parsed report fields", errors)
+
+    def test_rejects_not_ready_without_a_mechanical_blocker(self) -> None:
+        errors = self.validate(report(run_scope_body=run_scope(status="Not ready")))
+        self.assertIn("Not ready status is not supported by parsed report fields", errors)
 
     def test_rejects_an_invalid_overall_status(self) -> None:
         errors = self.validate(report(run_scope_body=run_scope().replace("status: Ready", "status: Unknown")))

--- a/skills/agentic-readiness-assessment/tests/test_validate_report.py
+++ b/skills/agentic-readiness-assessment/tests/test_validate_report.py
@@ -62,7 +62,7 @@ GLOSSARY = """| Term | Meaning |
 Gate 3 anchor: Area 5 — unit tests are the primary verification surface for this repository."""
 
 
-def run_scope(*, raw_total: int = 105, normalized_score: int = 100, setup_score: int = 10) -> str:
+def run_scope(*, raw_total: int = 105, normalized_score: int = 100, setup_score: int = 10, status: str = "Ready", confidence: str = "High", probe: str = "pass") -> str:
     return f"""```yaml
 audited_by: agent
 prompt_version: 4.4.0
@@ -79,8 +79,8 @@ clean_state_setup: verified
 normalized_score: {normalized_score}
 raw_total: {raw_total}
 applicable_maximum: 105
-status: Ready
-confidence: High
+status: {status}
+confidence: {confidence}
 gates:
   setup:
     anchor: 2
@@ -92,7 +92,7 @@ gates:
     anchor: 5
     score: 10
   probe:
-    result: pass
+    result: {probe}
 ```"""
 
 
@@ -160,6 +160,10 @@ class ValidateReportTests(unittest.TestCase):
         errors = self.validate(report(glossary=GLOSSARY.rsplit("\n\n", 1)[0]))
         self.assertIn("missing Gate 3 anchor sentence", errors)
 
+    def test_rejects_glossary_content_after_the_gate_three_anchor_sentence(self) -> None:
+        errors = self.validate(report(glossary=f"{GLOSSARY}\n\nExtra prose."))
+        self.assertIn("glossary does not match the fixed contract", errors)
+
     def test_rejects_a_yaml_block_outside_run_and_scope(self) -> None:
         malformed = report(run_scope_body="Content").replace("## Confidence and Limits\n\nContent", f"## Confidence and Limits\n\n{run_scope()}")
         self.assertIn("missing Run and Scope YAML block", self.validate(malformed))
@@ -189,6 +193,21 @@ class ValidateReportTests(unittest.TestCase):
     def test_rejects_an_invalid_overall_status(self) -> None:
         errors = self.validate(report(run_scope_body=run_scope().replace("status: Ready", "status: Unknown")))
         self.assertIn("invalid Run and Scope status: Unknown", errors)
+
+    def test_rejects_ready_when_confidence_is_low(self) -> None:
+        errors = self.validate(report(run_scope_body=run_scope(confidence="Low")))
+        self.assertIn("Ready status is not supported by parsed report fields", errors)
+
+    def test_rejects_partially_ready_when_the_probe_failed(self) -> None:
+        errors = self.validate(report(run_scope_body=run_scope(status="Partially ready", probe="fail")))
+        self.assertIn("Partially ready status is not supported by parsed report fields", errors)
+
+    def test_rejects_a_missing_compact_index_with_no_records(self) -> None:
+        self.assertIn("missing What to Fix compact index", self.validate(report(fixes="No findings.")))
+
+    def test_rejects_a_malformed_compact_index_separator(self) -> None:
+        malformed = fix_records().replace("| --- | --- | --- | --- | --- |", "| --- | --- |")
+        self.assertIn("malformed What to Fix compact index separator", self.validate(report(fixes=malformed)))
 
     def test_rejects_an_incomplete_fix_record(self) -> None:
         self.assertIn("F-01 is missing Fix Record field: Level", self.validate(report(fixes=fix_records(complete=False))))

--- a/skills/agentic-readiness-assessment/tests/test_validate_report.py
+++ b/skills/agentic-readiness-assessment/tests/test_validate_report.py
@@ -41,6 +41,25 @@ AREAS = (
     ("Context economy", 5),
 )
 FIX_FIELDS = ("Problem", "Blocks", "Evidence", "Priority", "Owner", "Target", "Fix", "Verify", "Level")
+GLOSSARY = """| Term | Meaning |
+|---|---|
+| Area | One of 14 scored readiness dimensions. Each has a weight shown as `Max`. |
+| Gate | One of 4 mandatory checks. A gate's result **is** its anchor area's score, not a separate number. Gates 1–3 pass only at full points. |
+| Probe | Gate 4. A deliberate small defect introduced and reverted, to test whether the repository's own verification catches a real break. |
+| `F-nn` | A Fix Record: one stable ID per problem, holding the finding and its fix together. |
+| Priority | P0 stops unattended work and needs a human. P1 lets the agent proceed incorrectly or unvalidated. P2 costs avoidable time or clarity. |
+| Owner | Who fixes it: `repo`, `agent-environment` (the agent's image or toolchain), `platform` (org or infra config), or `external-service`. |
+| Readiness status | Per area: Verified (full points), Partial (half, rounded down), Repository-blocked (0), or N/A (excluded from the maximum). |
+| Verification state | How the evidence was obtained: Executed, Executed (unfrozen fallback), CI-proven, Environment-blocked, Not run: unsafe, or Not applicable. |
+| Level | What a fix changes: `code`, `control`, `docs`, or `instructions`. |
+| Normalized score | `points earned / applicable maximum * 100`. The applicable maximum is 105 minus the weight of every N/A area, so it is rarely 100. |
+| Repository blocker | The repository itself is missing, wrong, unsafe, or contradictory. Counts against readiness. |
+| Environment blocker | The repository documents enough, but this audit machine lacked a tool, service, or permission. Caps confidence; never a full zero. |
+| Enforced control | Something that actually fails when violated. A rule that lives only in prose is documented guidance, not an enforced control. |
+| Negative control | A safety defect such as a permission bypass, allow-all policy, unguarded secret file, or committed plaintext credential. Caps area 13 at 2. |
+| Unfrozen fallback | The locked install failed, so a non-mutating unlocked install was used instead. Valid evidence, but caps the setup area at half. |
+
+Gate 3 anchor: Area 5 — unit tests are the primary verification surface for this repository."""
 
 
 def run_scope(*, raw_total: int = 105, normalized_score: int = 100, setup_score: int = 10) -> str:
@@ -94,7 +113,7 @@ def fix_records(*, complete: bool = True) -> str:
     return "\n".join(body)
 
 
-def report(*, sections: tuple[str, ...] = SECTIONS, run_scope_body: str | None = None, glossary: str = "| Term | Meaning |\n| --- | --- |", scorecard_body: str | None = None, fixes: str | None = None) -> str:
+def report(*, sections: tuple[str, ...] = SECTIONS, run_scope_body: str | None = None, glossary: str = GLOSSARY, scorecard_body: str | None = None, fixes: str | None = None) -> str:
     bodies = {
         "Run and Scope": run_scope() if run_scope_body is None else run_scope_body,
         "Glossary": glossary,
@@ -127,16 +146,27 @@ class ValidateReportTests(unittest.TestCase):
         self.assertIn("sections are not in the required order", self.validate(report(sections=tuple(sections))))
 
     def test_rejects_an_unreadable_report(self) -> None:
-        errors = validate_report.validate(Path("does-not-exist.md"))
-        self.assertEqual(errors, ["cannot read report: does-not-exist.md"])
+        self.assertEqual(validate_report.validate(Path("does-not-exist.md")), ["cannot read report: does-not-exist.md"])
 
     def test_rejects_glossary_text_that_is_not_a_header_row(self) -> None:
         errors = self.validate(report(glossary="The required header is | Term | Meaning |."))
         self.assertIn("missing glossary table header", errors)
 
+    def test_rejects_an_incomplete_fixed_glossary(self) -> None:
+        errors = self.validate(report(glossary=GLOSSARY.replace("| Probe |", "| Test probe |")))
+        self.assertIn("glossary does not match the fixed table", errors)
+
+    def test_rejects_a_missing_gate_three_anchor_sentence(self) -> None:
+        errors = self.validate(report(glossary=GLOSSARY.rsplit("\n\n", 1)[0]))
+        self.assertIn("missing Gate 3 anchor sentence", errors)
+
     def test_rejects_a_yaml_block_outside_run_and_scope(self) -> None:
         malformed = report(run_scope_body="Content").replace("## Confidence and Limits\n\nContent", f"## Confidence and Limits\n\n{run_scope()}")
         self.assertIn("missing Run and Scope YAML block", self.validate(malformed))
+
+    def test_rejects_run_and_scope_keys_out_of_order(self) -> None:
+        malformed = run_scope().replace("audited_by: agent\nprompt_version: 4.4.0", "prompt_version: 4.4.0\naudited_by: agent")
+        self.assertIn("Run and Scope keys are not in the required order", self.validate(report(run_scope_body=malformed)))
 
     def test_rejects_a_missing_gate_map_entry(self) -> None:
         malformed = run_scope().replace("  probe:\n    result: pass\n", "")
@@ -162,6 +192,16 @@ class ValidateReportTests(unittest.TestCase):
 
     def test_rejects_an_incomplete_fix_record(self) -> None:
         self.assertIn("F-01 is missing Fix Record field: Level", self.validate(report(fixes=fix_records(complete=False))))
+
+    def test_rejects_an_index_id_without_one_matching_record(self) -> None:
+        malformed = fix_records().replace("### F-01", "### F-02")
+        errors = self.validate(report(fixes=malformed))
+        self.assertIn("index Fix Record F-01 does not have exactly one matching record", errors)
+        self.assertIn("Fix Record F-02 is not declared in the index", errors)
+
+    def test_rejects_a_malformed_fix_record_declaration(self) -> None:
+        malformed = fix_records().replace("### F-01", "### F-1")
+        self.assertIn("malformed Fix Record declaration: F-1", self.validate(report(fixes=malformed)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

- add deterministic validation for the assessment report contract
- document host execution evidence and assessment delegation decisions
- add dependency-free validator regression tests

## Motivation and Context

Makes agentic-readiness reports mechanically verifiable while recording host-runtime limits without claiming portable enforcement.

## How Has This Been Tested

- `python3 -m unittest discover -s skills/agentic-readiness-assessment/tests -v` (22 passing)
- `python3 -m json.tool` on all plugin JSON manifests
- `git diff --check main...HEAD`

## Types of changes

- [x] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change

## Checklist

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the CONTRIBUTING document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.