### PR TITLE
ci: record CLA signatures on pull requests

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,40 @@
+name: CLA
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, synchronize, closed]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  cla:
+    name: Check or record the CLA signature
+    runs-on: ubuntu-latest
+    steps:
+      - name: CLA assistant
+        if: (github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        # Pinned to the v2.6.1 commit. The upstream repository is archived, so the
+        # tag can never move and no new releases are coming. If it ever breaks,
+        # fork it into exadel-inc and point this line at the fork.
+        uses: contributor-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-signatures: signatures/v1/cla.json
+          path-to-document: https://github.com/exadel-inc/agentic-readiness-assessment/blob/main/CLA.md
+          branch: cla-signatures
+          allowlist: '*[bot]'
+          custom-notsigned-prcomment: >-
+            Thank you for the contribution. Before it can be merged, please read the
+            [Contributor License Agreement](https://github.com/exadel-inc/agentic-readiness-assessment/blob/main/CLA.md)
+            and accept it by posting the sentence below as a comment on this pull request.
+            You only ever do this once, and it covers every contribution you make to this repository.
+          custom-pr-sign-comment: I have read the CLA Document and I hereby sign the CLA
+          custom-allsigned-prcomment: Every contributor on this pull request has signed the CLA.
+          lock-pullrequest-aftermerge: false


### PR DESCRIPTION
## The problem

`CLA.md` says the agreement "shall come into effect upon Your acceptance of its terms and conditions", and nothing in this repository records acceptance. A contributor agreement nobody has accepted grants nothing. `CONTRIBUTING.md` already promises the flow (sign by commenting on your pull request), and until now no bot existed to deliver it.

Nothing here is retroactive. Every contributor so far is inside Exadel, whose work is covered by employment rather than by this agreement. The gap bites the first time an outsider opens a pull request, which has not happened yet.

## What this adds

One workflow. A first-time contributor gets a comment asking them to read `CLA.md` and accept it by replying with a fixed sentence. The bot records who signed, when, on which pull request and at which commit, into `signatures/v1/cla.json` on a `cla-signatures` branch in this repository. No external service holds the record. Existing contributors sign once and never again. Bots are allowlisted.

Worth being clear about why the file exists at all: Apache-2.0 section 5 already licenses inbound contributions on Apache terms, so the CLA is not needed to accept a pull request. What it adds, in section 2, is the right to **sublicense**, which is what would let Exadel relicense a contribution outside Apache-2.0.

## Two things a reviewer should push back on if they disagree

**The upstream action is archived.** Last release 2024-09-26, repository read-only since. It is still the most widely used CLA workflow on GitHub and it still runs, but it will get no fixes. Mitigations taken: it is pinned to the v2.6.1 **commit** rather than a moving tag, so the code that executes cannot change underneath us. If it ever breaks, fork it into `exadel-inc` and repoint one line.

I looked for a maintained alternative and there is not a good one. `cla-assistant.io` is reachable but its codebase has not been pushed since 2024-06-06, and it puts the signature records on someone else's server. DCO is actively maintained and is the wrong tool: it certifies that a contributor has the right to submit, and grants no sublicense, which is the entire reason `CLA.md` exists.

The honest alternative to this PR, if the archived dependency is unacceptable, is a checkbox in the pull request template stating that opening a pull request constitutes acceptance. Weaker, because a checkbox is easier to argue was never read, but it has no dependency at all. Happy to swap.

## Not touched

`CLA.md` itself. It has two defects that want a legal opinion rather than a developer edit: it skips from section 9 to section 11, so there is no section 10, and it is an individual agreement with no corporate counterpart, which matters the first time somebody contributes on an employer's time.

## The open question this does not answer

@michalcichon asked in #3 whether a formal electronic or handwritten signature is required, or whether the file in the repository is enough. This PR takes the middle position that the wider open-source world takes: a recorded comment, with an audit trail, is acceptance. Whether Exadel legal agrees is a question for them, and it is a narrow one worth asking as written rather than as a general "what should we do about the CLA".